### PR TITLE
Pin the production Public Lyrics source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV NEXT_PUBLIC_OAUTH2_CLIENT_ID=snowy-viewer-public
 # sitemap generation derives index.json from the same explicitly supplied source.
 # CI may mount a short-lived synthetic CA only for the required image build contract;
 # the secret is available to this build step only and is never copied into the image.
-ARG NEXT_PUBLIC_LYRICS_BASE_URL=https://translation.exmeaning.com/files/translation/lyrics
+ARG NEXT_PUBLIC_LYRICS_BASE_URL=https://translation.exmeaning.com/translation/lyrics
 ENV NEXT_PUBLIC_LYRICS_BASE_URL=$NEXT_PUBLIC_LYRICS_BASE_URL
 # Build-time data sources. Multiple URLs allow Docker builds to survive flaky DNS/proxy/CDN paths.
 ARG MASTER_DATA_URLS=https://metadata.exmeaning.com/{region}/master,https://metadata.pjsk.moe/{region}/master
@@ -56,7 +56,7 @@ RUN CGO_ENABLED=0 go build -ldflags="-w -s" -o server main.go
 FROM node:22.17.1-alpine3.22
 WORKDIR /app
 
-ARG NEXT_PUBLIC_LYRICS_BASE_URL=https://translation.exmeaning.com/files/translation/lyrics
+ARG NEXT_PUBLIC_LYRICS_BASE_URL=https://translation.exmeaning.com/translation/lyrics
 ENV NEXT_PUBLIC_LYRICS_BASE_URL=$NEXT_PUBLIC_LYRICS_BASE_URL
 RUN test -n "$NEXT_PUBLIC_LYRICS_BASE_URL"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV NEXT_PUBLIC_OAUTH2_CLIENT_ID=snowy-viewer-public
 # sitemap generation derives index.json from the same explicitly supplied source.
 # CI may mount a short-lived synthetic CA only for the required image build contract;
 # the secret is available to this build step only and is never copied into the image.
-ARG NEXT_PUBLIC_LYRICS_BASE_URL
+ARG NEXT_PUBLIC_LYRICS_BASE_URL=https://translation.exmeaning.com/files/translation/lyrics
 ENV NEXT_PUBLIC_LYRICS_BASE_URL=$NEXT_PUBLIC_LYRICS_BASE_URL
 # Build-time data sources. Multiple URLs allow Docker builds to survive flaky DNS/proxy/CDN paths.
 ARG MASTER_DATA_URLS=https://metadata.exmeaning.com/{region}/master,https://metadata.pjsk.moe/{region}/master
@@ -56,7 +56,7 @@ RUN CGO_ENABLED=0 go build -ldflags="-w -s" -o server main.go
 FROM node:22.17.1-alpine3.22
 WORKDIR /app
 
-ARG NEXT_PUBLIC_LYRICS_BASE_URL
+ARG NEXT_PUBLIC_LYRICS_BASE_URL=https://translation.exmeaning.com/files/translation/lyrics
 ENV NEXT_PUBLIC_LYRICS_BASE_URL=$NEXT_PUBLIC_LYRICS_BASE_URL
 RUN test -n "$NEXT_PUBLIC_LYRICS_BASE_URL"
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ AGPL-3.0
 ### 前端配置 (Next.js Web - standalone 部署)
 
 - **NEXT_PUBLIC_API_URL**: 关联活动/卡池等 API 的后端基准地址；使用当前 standalone + 内置反向代理部署时通常无需配置，前后端分离部署时可设为例如 `https://api.pjsk.moe`。
-- **NEXT_PUBLIC_LYRICS_BASE_URL**: 必填的已发布歌词资产目录。生产运行与构建只接受不含凭据、query 或 fragment 的 HTTPS URL；开发环境还允许显式配置本机回环 HTTP URL。页面与 sitemap 都从该目录读取同一份 `index.json`，避免发布视图分叉。变量缺失或无效时会直接失败，不会静默切换到其他源。`Dockerfile` 的 production 默认地址固定为 `https://translation.exmeaning.com/files/translation/lyrics`；CI 和明确隔离的非生产环境仍可通过 `--build-arg NEXT_PUBLIC_LYRICS_BASE_URL="$NEXT_PUBLIC_LYRICS_BASE_URL"` 覆盖，`docker-compose.dev.yml` 继续只透传开发变量。Required PR CI 使用仅在 job 生命周期内存在的一首 strict Public Lyrics v3 Full-only synthetic HTTPS index/detail fixture 验证生产 Docker/Next build contract，临时 CA 通过 BuildKit secret 只挂载到构建步骤且不会进入镜像；这不证明真实生产源可达。NEXT 首次部署后，release/deployment gate 必须对该固定 production 地址完成 source smoke；只有明确隔离的非生产或迁移场景才可从受保护环境变量覆盖，定时 sitemap 也必须使用同一个已验证地址。不要把令牌或个人配置提交到仓库。
+- **NEXT_PUBLIC_LYRICS_BASE_URL**: 必填的已发布歌词资产目录。生产运行与构建只接受不含凭据、query 或 fragment 的 HTTPS URL；开发环境还允许显式配置本机回环 HTTP URL。页面与 sitemap 都从该目录读取同一份 `index.json`，避免发布视图分叉。变量缺失或无效时会直接失败，不会静默切换到其他源。`Dockerfile` 的 production 默认地址固定为 `https://translation.exmeaning.com/translation/lyrics`；CI 和明确隔离的非生产环境仍可通过 `--build-arg NEXT_PUBLIC_LYRICS_BASE_URL="$NEXT_PUBLIC_LYRICS_BASE_URL"` 覆盖，`docker-compose.dev.yml` 继续只透传开发变量。Required PR CI 使用仅在 job 生命周期内存在的一首 strict Public Lyrics v3 Full-only synthetic HTTPS index/detail fixture 验证生产 Docker/Next build contract，临时 CA 通过 BuildKit secret 只挂载到构建步骤且不会进入镜像；这不证明真实生产源可达。NEXT 首次部署后，release/deployment gate 必须对该固定 production 地址完成 source smoke；只有明确隔离的非生产或迁移场景才可从受保护环境变量覆盖，定时 sitemap 也必须使用同一个已验证地址。不要把令牌或个人配置提交到仓库。
 
 ## Docker 部署
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ AGPL-3.0
 ### 前端配置 (Next.js Web - standalone 部署)
 
 - **NEXT_PUBLIC_API_URL**: 关联活动/卡池等 API 的后端基准地址；使用当前 standalone + 内置反向代理部署时通常无需配置，前后端分离部署时可设为例如 `https://api.pjsk.moe`。
-- **NEXT_PUBLIC_LYRICS_BASE_URL**: 必填的已发布歌词资产目录。生产运行与构建只接受不含凭据、query 或 fragment 的 HTTPS URL；开发环境还允许显式配置本机回环 HTTP URL。页面与 sitemap 都从该目录读取同一份 `index.json`，避免发布视图分叉。变量缺失或无效时会直接失败，不会静默切换到其他源。`Dockerfile` 不提供默认地址，构建全量镜像前必须通过 `--build-arg NEXT_PUBLIC_LYRICS_BASE_URL="$NEXT_PUBLIC_LYRICS_BASE_URL"` 显式传入；`docker-compose.dev.yml` 也只透传该变量。Required PR CI 使用仅在 job 生命周期内存在的一首 strict Public Lyrics v3 Full-only synthetic HTTPS index/detail fixture 验证生产 Docker/Next build contract，临时 CA 通过 BuildKit secret 只挂载到构建步骤且不会进入镜像；这不证明真实生产源可达。NEXT 首次部署后，release/deployment gate 仍必须从受保护环境变量读取真实 HTTPS 地址并完成 source smoke，定时 sitemap 也继续要求真实仓库变量。请在当前 shell、CI variable 或未提交的本地环境文件中设置真实地址，不要把令牌、个人配置或环境专属主机名提交到仓库。
+- **NEXT_PUBLIC_LYRICS_BASE_URL**: 必填的已发布歌词资产目录。生产运行与构建只接受不含凭据、query 或 fragment 的 HTTPS URL；开发环境还允许显式配置本机回环 HTTP URL。页面与 sitemap 都从该目录读取同一份 `index.json`，避免发布视图分叉。变量缺失或无效时会直接失败，不会静默切换到其他源。`Dockerfile` 的 production 默认地址固定为 `https://translation.exmeaning.com/files/translation/lyrics`；CI 和明确隔离的非生产环境仍可通过 `--build-arg NEXT_PUBLIC_LYRICS_BASE_URL="$NEXT_PUBLIC_LYRICS_BASE_URL"` 覆盖，`docker-compose.dev.yml` 继续只透传开发变量。Required PR CI 使用仅在 job 生命周期内存在的一首 strict Public Lyrics v3 Full-only synthetic HTTPS index/detail fixture 验证生产 Docker/Next build contract，临时 CA 通过 BuildKit secret 只挂载到构建步骤且不会进入镜像；这不证明真实生产源可达。NEXT 首次部署后，release/deployment gate 必须对该固定 production 地址完成 source smoke；只有明确隔离的非生产或迁移场景才可从受保护环境变量覆盖，定时 sitemap 也必须使用同一个已验证地址。不要把令牌或个人配置提交到仓库。
 
 ## Docker 部署
 

--- a/web/tests/characterization/security-release.characterization.test.mjs
+++ b/web/tests/characterization/security-release.characterization.test.mjs
@@ -81,7 +81,7 @@ test("production and web-dev images install from the frozen workspace root and r
   assert.match(production, /COPY package\.json bun\.lock \.\//);
   assert.match(production, /RUN bun install --frozen-lockfile/);
   assert.equal(
-    production.match(/^ARG NEXT_PUBLIC_LYRICS_BASE_URL=https:\/\/translation\.exmeaning\.com\/files\/translation\/lyrics$/gm)?.length,
+    production.match(/^ARG NEXT_PUBLIC_LYRICS_BASE_URL=https:\/\/translation\.exmeaning\.com\/translation\/lyrics$/gm)?.length,
     2,
   );
   assert.doesNotMatch(production, /^ARG NEXT_PUBLIC_LYRICS_BASE_URL$/m);
@@ -92,7 +92,7 @@ test("production and web-dev images install from the frozen workspace root and r
   assert.match(production, /COPY --from=builder-web[\s\S]*public-lyrics-base-url-build-contract/);
   assert.match(production, /export REQUIRE_PUBLIC_LYRICS_SOURCE=1;[\s\S]*bun run sitemap/);
   const productionWithoutReviewedLyricsDefault = production.replaceAll(
-    "ARG NEXT_PUBLIC_LYRICS_BASE_URL=https://translation.exmeaning.com/files/translation/lyrics",
+    "ARG NEXT_PUBLIC_LYRICS_BASE_URL=https://translation.exmeaning.com/translation/lyrics",
     "ARG NEXT_PUBLIC_LYRICS_BASE_URL=<reviewed-public-lyrics-base>",
   );
   assert.doesNotMatch(productionWithoutReviewedLyricsDefault, /NEXT_PUBLIC_LYRICS_BASE_URL=.*(?:https?:\/\/|token|password|@)/i);

--- a/web/tests/characterization/security-release.characterization.test.mjs
+++ b/web/tests/characterization/security-release.characterization.test.mjs
@@ -80,15 +80,22 @@ test("production and web-dev images install from the frozen workspace root and r
   assert.match(production, /FROM oven\/bun:1\.3\.14/);
   assert.match(production, /COPY package\.json bun\.lock \.\//);
   assert.match(production, /RUN bun install --frozen-lockfile/);
-  assert.match(production, /^ARG NEXT_PUBLIC_LYRICS_BASE_URL$/m);
-  assert.doesNotMatch(production, /^ARG NEXT_PUBLIC_LYRICS_BASE_URL=/m);
+  assert.equal(
+    production.match(/^ARG NEXT_PUBLIC_LYRICS_BASE_URL=https:\/\/translation\.exmeaning\.com\/files\/translation\/lyrics$/gm)?.length,
+    2,
+  );
+  assert.doesNotMatch(production, /^ARG NEXT_PUBLIC_LYRICS_BASE_URL$/m);
   assert.match(production, /ENV NODE_ENV=production[\s\S]*bun run sitemap/);
   assert.match(production, /ENV NEXT_PUBLIC_LYRICS_BASE_URL=\$NEXT_PUBLIC_LYRICS_BASE_URL/);
   assert.match(production, /RUN test -n "\$NEXT_PUBLIC_LYRICS_BASE_URL"/);
   assert.match(production, /RUN printf '%s\\n' "\$NEXT_PUBLIC_LYRICS_BASE_URL" > \/app\/public-lyrics-base-url-build-contract/);
   assert.match(production, /COPY --from=builder-web[\s\S]*public-lyrics-base-url-build-contract/);
   assert.match(production, /export REQUIRE_PUBLIC_LYRICS_SOURCE=1;[\s\S]*bun run sitemap/);
-  assert.doesNotMatch(production, /NEXT_PUBLIC_LYRICS_BASE_URL=.*(?:https?:\/\/|token|password|@)/i);
+  const productionWithoutReviewedLyricsDefault = production.replaceAll(
+    "ARG NEXT_PUBLIC_LYRICS_BASE_URL=https://translation.exmeaning.com/files/translation/lyrics",
+    "ARG NEXT_PUBLIC_LYRICS_BASE_URL=<reviewed-public-lyrics-base>",
+  );
+  assert.doesNotMatch(productionWithoutReviewedLyricsDefault, /NEXT_PUBLIC_LYRICS_BASE_URL=.*(?:https?:\/\/|token|password|@)/i);
   const startContainer = readRepo("scripts/start-container.sh");
   assert.match(startContainer, /public-lyrics-base-url-build-contract/);
   assert.match(startContainer, /does not match the build-time public lyrics source/);


### PR DESCRIPTION
## Summary

- default production Docker builds to `https://translation.exmeaning.com/files/translation/lyrics`
- retain explicit build-arg overrides for CI and isolated non-production environments
- preserve the build/runtime source equality and fail-closed sitemap contract

## Verification

- characterization: 112/112
- TypeScript: passed
- ESLint: passed
- Public Lyrics fixture: 4/4
- focused security-release characterization: 6/6
- `git diff --check`: passed

## Deployment order

The fixed URL currently returns 404 until the NextTrans 700 database/public projection is deployed. Do not rerun the MoeSekai production deployment before that source is live and its `index.json` passes smoke.