### PR TITLE
Fix lyrics metadata fallback for JP-only songs

### DIFF
--- a/web/src/app/lyrics/[musicId]/client.tsx
+++ b/web/src/app/lyrics/[musicId]/client.tsx
@@ -11,7 +11,6 @@ import Link from "@/components/LocalizedLink";
 import { useBreadcrumb } from "@/contexts/BreadcrumbContext";
 import { useI18n } from "@/contexts/I18nContext";
 import { useTheme } from "@/contexts/ThemeContext";
-import { fetchMasterData } from "@/lib/fetch";
 import {
     fetchLyricsDocument,
     getLyricsDisplayLines,
@@ -29,11 +28,10 @@ import {
     type ILyricsV3ComponentAttribution,
     type LyricsVersion,
 } from "@/lib/lyrics";
+import { fetchLyricsMusicById } from "@/lib/lyrics-music-source";
 import { replaceCurrentUrlSearchParams } from "@/lib/localized-path";
-import type { IMusicInfo, MusicCategoryType } from "@/types/music";
+import type { IMusicInfo } from "@/types/music";
 import { getMusicJacketUrl, MUSIC_CATEGORY_COLORS } from "@/types/music";
-
-type RawMusicCategory = MusicCategoryType | { musicCategoryName: MusicCategoryType };
 type LyricsDisplayAttribution = ILyricsAttribution | ILyricsV3ComponentAttribution;
 
 function getLyricsDisplayAttributions(attributions: readonly LyricsDisplayAttribution[]): LyricsDisplayAttribution[] {
@@ -77,33 +75,22 @@ export default function LyricsDetailClient() {
         if (!hasValidMusicId) return;
         let cancelled = false;
         Promise.all([
-            fetchMasterData<IMusicInfo[]>("musics.json"),
+            fetchLyricsMusicById(musicId),
             getPublishedLyricsIndexEntry(musicId),
             fetchLyricsDocument(musicId).then(
                 (document) => ({ document, error: null as unknown }),
                 (error: unknown) => ({ document: null, error }),
             ),
         ])
-            .then(([musics, publication, detail]) => {
+            .then(([music, publication, detail]) => {
                 if (cancelled) return;
-                const foundMusic = musics.find((item) => item.id === musicId) ?? null;
-                const normalizedMusic = foundMusic
-                    ? {
-                        ...foundMusic,
-                        categories: ((foundMusic.categories ?? []) as unknown as RawMusicCategory[]).map((category) =>
-                            typeof category === "object" && category !== null && "musicCategoryName" in category
-                                ? category.musicCategoryName
-                                : category
-                        ),
-                    }
-                    : null;
                 const errorKind = detail.error
                     ? isLyricsUnavailableError(detail.error) ? publication ? "unavailable" : "not-found" : "failed"
                     : null;
                 setResult({
                     musicId,
                     locale,
-                    music: normalizedMusic,
+                    music,
                     publication,
                     lyrics: detail.document,
                     errorKind,

--- a/web/src/app/lyrics/client.tsx
+++ b/web/src/app/lyrics/client.tsx
@@ -18,10 +18,9 @@ import {
     hasLyricsDetail,
     type ILyricsIndexEntry,
 } from "@/lib/lyrics";
+import { fetchLyricsMusicCatalog } from "@/lib/lyrics-music-source";
 import { replaceCurrentUrlSearchParams } from "@/lib/localized-path";
 import type { IMusicInfo, IMusicTagInfo, MusicCategoryType, MusicTagType } from "@/types/music";
-
-type RawMusicCategory = MusicCategoryType | { musicCategoryName: MusicCategoryType };
 
 function LyricsContent() {
     const searchParams = useSearchParams();
@@ -57,23 +56,19 @@ function LyricsContent() {
 
     useEffect(() => {
         let cancelled = false;
+        const indexRequest = fetchLyricsIndex();
         Promise.all([
-            fetchLyricsIndex(),
-            fetchMasterData<IMusicInfo[]>("musics.json"),
+            indexRequest,
+            indexRequest.then((index) => fetchLyricsMusicCatalog(new Set(
+                index.songs.filter(hasLyricsDetail).map((item) => item.musicId),
+            ))),
             fetchMasterData<IMusicTagInfo[]>("musicTags.json"),
             fetchMasterData<{ musicId: number }[]>("eventMusics.json"),
         ])
             .then(([index, musicData, tags, eventMusics]) => {
                 if (cancelled) return;
                 setLyricsByMusicId(new Map(index.songs.map((item) => [item.musicId, item])));
-                setMusics(musicData.map((music) => ({
-                    ...music,
-                    categories: (music.categories as unknown as RawMusicCategory[]).map((category) =>
-                        typeof category === "object" && category !== null && "musicCategoryName" in category
-                            ? category.musicCategoryName
-                            : category
-                    ),
-                })));
+                setMusics(musicData);
                 setMusicTags(tags);
                 setEventMusicIds(new Set(eventMusics.map((item) => item.musicId)));
                 setError(null);

--- a/web/src/lib/lyrics-music-catalog.ts
+++ b/web/src/lib/lyrics-music-catalog.ts
@@ -1,0 +1,40 @@
+import type { IMusicInfo, MusicCategoryType } from "@/types/music";
+
+type RawMusicCategory = MusicCategoryType | { musicCategoryName: MusicCategoryType };
+
+export function normalizeLyricsMusic(music: IMusicInfo): IMusicInfo {
+    return {
+        ...music,
+        categories: ((music.categories ?? []) as unknown as RawMusicCategory[]).map((category) =>
+            typeof category === "object" && category !== null && "musicCategoryName" in category
+                ? category.musicCategoryName
+                : category
+        ),
+    };
+}
+
+export function findLyricsMusic(
+    musicId: number,
+    currentRegionMusics: readonly IMusicInfo[],
+    japaneseMusics: readonly IMusicInfo[] = [],
+): IMusicInfo | null {
+    const music = currentRegionMusics.find((item) => item.id === musicId)
+        ?? japaneseMusics.find((item) => item.id === musicId)
+        ?? null;
+    return music ? normalizeLyricsMusic(music) : null;
+}
+
+export function mergePublishedLyricsMusicCatalog(
+    currentRegionMusics: readonly IMusicInfo[],
+    japaneseMusics: readonly IMusicInfo[],
+    publishedMusicIds: ReadonlySet<number>,
+): IMusicInfo[] {
+    const merged = currentRegionMusics.map(normalizeLyricsMusic);
+    const existingIds = new Set(merged.map((music) => music.id));
+    for (const music of japaneseMusics) {
+        if (!publishedMusicIds.has(music.id) || existingIds.has(music.id)) continue;
+        merged.push(normalizeLyricsMusic(music));
+        existingIds.add(music.id);
+    }
+    return merged;
+}

--- a/web/src/lib/lyrics-music-source.ts
+++ b/web/src/lib/lyrics-music-source.ts
@@ -1,0 +1,42 @@
+import { fetchMasterData, fetchMasterDataForServer } from "@/lib/fetch";
+import {
+    findLyricsMusic,
+    mergePublishedLyricsMusicCatalog,
+    normalizeLyricsMusic,
+} from "@/lib/lyrics-music-catalog";
+import type { IMusicInfo } from "@/types/music";
+
+async function fetchCurrentRegionMusics(): Promise<IMusicInfo[]> {
+    return fetchMasterData<IMusicInfo[]>("musics.json");
+}
+
+async function fetchJapaneseMusics(): Promise<IMusicInfo[]> {
+    return fetchMasterDataForServer<IMusicInfo[]>("jp", "musics.json");
+}
+
+export async function fetchLyricsMusicCatalog(publishedMusicIds: ReadonlySet<number>): Promise<IMusicInfo[]> {
+    const currentRegionMusics = await fetchCurrentRegionMusics();
+    const currentRegionIds = new Set(currentRegionMusics.map((music) => music.id));
+    if ([...publishedMusicIds].every((musicId) => currentRegionIds.has(musicId))) {
+        return currentRegionMusics.map(normalizeLyricsMusic);
+    }
+
+    try {
+        const japaneseMusics = await fetchJapaneseMusics();
+        return mergePublishedLyricsMusicCatalog(currentRegionMusics, japaneseMusics, publishedMusicIds);
+    } catch {
+        return currentRegionMusics.map(normalizeLyricsMusic);
+    }
+}
+
+export async function fetchLyricsMusicById(musicId: number): Promise<IMusicInfo | null> {
+    const currentRegionMusics = await fetchCurrentRegionMusics();
+    const currentRegionMusic = findLyricsMusic(musicId, currentRegionMusics);
+    if (currentRegionMusic) return currentRegionMusic;
+
+    try {
+        return findLyricsMusic(musicId, [], await fetchJapaneseMusics());
+    } catch {
+        return null;
+    }
+}

--- a/web/tests/characterization/lyrics-master-fallback.characterization.test.mjs
+++ b/web/tests/characterization/lyrics-master-fallback.characterization.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { importWebTypeScript, readWeb } from "./test-helpers.mjs";
+
+test("published lyrics merge missing JP music metadata without replacing regional records", async () => {
+  const catalog = await importWebTypeScript("src/lib/lyrics-music-catalog.ts");
+  const current = [{ id: 307, title: "regional", categories: [{ musicCategoryName: "mv" }] }];
+  const japanese = [
+    { id: 307, title: "japanese", categories: ["mv"] },
+    { id: 754, title: "光", categories: [{ musicCategoryName: "image" }] },
+    { id: 765, title: "レム", categories: ["mv"] },
+    { id: 789, title: "incomplete", categories: ["mv"] },
+  ];
+
+  const merged = catalog.mergePublishedLyricsMusicCatalog(current, japanese, new Set([307, 754, 765]));
+  assert.deepEqual(merged.map((music) => music.id), [307, 754, 765]);
+  assert.equal(merged[0].title, "regional", "current-region metadata must win for duplicate IDs");
+  assert.deepEqual(merged[0].categories, ["mv"]);
+  assert.deepEqual(merged[1].categories, ["image"]);
+  assert.equal(catalog.findLyricsMusic(754, current, japanese)?.title, "光");
+  assert.equal(catalog.findLyricsMusic(307, current, japanese)?.title, "regional");
+  assert.equal(catalog.findLyricsMusic(999, current, japanese), null);
+});
+
+test("lyrics pages use a current-region-first JP fallback only for published lyrics metadata", () => {
+  const source = readWeb("src/lib/lyrics-music-source.ts");
+  assert.match(source, /fetchMasterData<IMusicInfo\[]>\("musics\.json"\)/);
+  assert.match(source, /fetchMasterDataForServer<IMusicInfo\[]>\("jp", "musics\.json"\)/);
+  assert.match(source, /every\(\(musicId\) => currentRegionIds\.has\(musicId\)\)/);
+  assert.match(source, /mergePublishedLyricsMusicCatalog\(currentRegionMusics, japaneseMusics, publishedMusicIds\)/);
+  assert.match(source, /catch \{[\s\S]*return currentRegionMusics\.map\(normalizeLyricsMusic\)/);
+
+  const list = readWeb("src/app/lyrics/client.tsx");
+  assert.match(list, /fetchLyricsMusicCatalog\(new Set\([\s\S]*index\.songs\.filter\(hasLyricsDetail\)/);
+  assert.match(list, /setMusics\(musicData\)/);
+
+  const detail = readWeb("src/app/lyrics/\[musicId\]/client.tsx");
+  assert.match(detail, /fetchLyricsMusicById\(musicId\)/);
+  assert.doesNotMatch(detail, /fetchMasterData<IMusicInfo\[]>\("musics\.json"\)/);
+});

--- a/web/tests/characterization/lyrics.characterization.test.mjs
+++ b/web/tests/characterization/lyrics.characterization.test.mjs
@@ -394,7 +394,7 @@ async function importLyricsDetailClient(lyrics) {
     const React = dependencies.React;
     const { useEffect, useState } = React;
     const { Image, useParams, useSearchParams, ExternalLink, MainLayout, LyricText, Link, useBreadcrumb, useI18n, useTheme,
-      fetchMasterData, fetchLyricsDocument, getLyricsDisplayLines, getLyricsDisplaySegments, getLyricsRendition, getLyricsRenditions,
+      fetchLyricsMusicById, fetchLyricsDocument, getLyricsDisplayLines, getLyricsDisplaySegments, getLyricsRendition, getLyricsRenditions,
       getLyricsTargetLocale, hasFullLyricsVersion, hasGameLyricsVersion, isLyricsUnavailableError, replaceCurrentUrlSearchParams,
       getPublishedLyricsIndexEntry, getMusicJacketUrl, MUSIC_CATEGORY_COLORS } = dependencies;
   `;
@@ -446,7 +446,7 @@ async function importLyricsDetailClient(lyrics) {
       return { locale: "en-US", t: translate, formatDate: (value) => String(value) };
     },
     useTheme: () => ({ assetSource: "main" }),
-    fetchMasterData: async () => state.musics,
+    fetchLyricsMusicById: async (musicId) => state.musics.find((music) => music.id === musicId) ?? null,
     getPublishedLyricsIndexEntry: async (musicId) => {
       if (state.publication) return state.publication;
       const sourceIndex = state.document?.version === 2 ? fixtureV2.index : fixture.index;


### PR DESCRIPTION
## Summary

- keep current-region music metadata authoritative when the song exists there
- for published lyrics whose music metadata is missing in the selected region, fill only those missing records from the JP master
- apply the same fallback to the lyrics list and direct detail routes without changing ordinary music pages or restoring hidden lyrics entry points
- degrade to the existing regional catalog if the JP fallback request is unavailable

## Production finding

The accepted 700-song lyrics index has 653 published details. The current CN master covers 555 of them; JP metadata fills the remaining 98 with no unresolved IDs. Without this fallback, direct pages such as 754 and 765 render the unavailable shell for default zh-CN users even though their public lyrics are live.

## Verification

- focused fallback characterization: 2/2
- full characterization: 114/114
- i18n/SEO checks: passed
- TypeScript: passed
- ESLint: passed
- Next.js production build: 73 routes passed
- live inventory join: 653 details, 555 CN + 98 JP fallback, 0 missing
- `git diff --check`: passed

## Deployment

NextTrans 700 Public Lyrics v3 is already live and passed production smoke. This follow-up does not expose the hidden navigation/search/music-detail lyrics entry points; it only makes preserved direct routes and the future list usable for JP-only songs.