### PR TITLE
音乐别名展示：详情页别名展开 + 列表搜索命中别名提示

### DIFF
--- a/web/src/app/music/[id]/client.tsx
+++ b/web/src/app/music/[id]/client.tsx
@@ -34,6 +34,7 @@ import { fetchSongConstants, buildSongConstantsMap } from "@/lib/songConstants";
 import { getPublishedLyricsIndexEntry, hasLyricsDetail } from "@/lib/lyrics";
 import { LYRICS_ENTRY_VISIBLE } from "@/lib/lyrics-visibility";
 import { fetchMusicBpmMap, getMusicBpm, formatBpmValue, formatBarValue, MusicBpmEntry } from "@/lib/musicBpm";
+import { fetchMusicAliases, getMusicAliases } from "@/lib/musicAliases";
 import ImagePreviewModal from "@/components/common/ImagePreviewModal";
 import { useI18n } from "@/contexts/I18nContext";
 
@@ -125,6 +126,10 @@ export default function MusicDetailPage() {
     // BPM states
     const [bpmEntry, setBpmEntry] = useState<MusicBpmEntry | null>(null);
     const [bpmListOpen, setBpmListOpen] = useState(false);
+
+    // Alias states
+    const [aliases, setAliases] = useState<string[]>([]);
+    const [aliasesOpen, setAliasesOpen] = useState(false);
 
     // View states
     const [selectedDifficulty, setSelectedDifficulty] = useState<MusicDifficultyType>("master");
@@ -300,6 +305,14 @@ export default function MusicDetailPage() {
                 } catch (err) {
                     console.warn("Failed to fetch music BPM:", err);
                 }
+
+                try {
+                    const aliasesMap = await fetchMusicAliases();
+                    setAliases(getMusicAliases(musicId, aliasesMap));
+                    setAliasesOpen(false);
+                } catch (err) {
+                    console.warn("Failed to load music aliases:", err);
+                }
             }
 
             fetchMetaData();
@@ -426,7 +439,7 @@ export default function MusicDetailPage() {
                         </div>
                     </div>
                     <div className="mb-2">
-                        <div className="inline-flex max-w-full items-start gap-2">
+                        <div className="inline-flex max-w-full flex-wrap items-start gap-2">
                             <h1 className="min-w-0 text-2xl font-black text-slate-800 sm:text-3xl">
                                 <TranslatedText
                                     original={music.title}
@@ -436,6 +449,23 @@ export default function MusicDetailPage() {
                                     translationClassName="block text-lg font-medium text-slate-400 mt-1"
                                 />
                             </h1>
+                            {aliases.length > 0 && (
+                                <button
+                                    type="button"
+                                    onClick={() => setAliasesOpen(v => !v)}
+                                    className="-translate-y-1 inline-flex items-center gap-0.5 whitespace-nowrap rounded-md border border-slate-300/70 bg-slate-50 px-1.5 py-0.5 text-[10px] font-bold text-slate-500 transition-colors hover:border-miku/60 hover:bg-miku/10 hover:text-miku sm:text-xs"
+                                    aria-expanded={aliasesOpen}
+                                    title={t("page.music.aliasesToggle")}
+                                >
+                                    {t("page.music.aliasesLabel")}
+                                    <svg
+                                        className={`w-3 h-3 transition-transform duration-200 ${aliasesOpen ? "rotate-180" : ""}`}
+                                        fill="none" viewBox="0 0 24 24" stroke="currentColor"
+                                    >
+                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M19 9l-7 7-7-7" />
+                                    </svg>
+                                </button>
+                            )}
                             {LYRICS_ENTRY_VISIBLE && hasPublishedLyrics && (
                                 <Link
                                     href={`/lyrics/${music.id}`}
@@ -446,6 +476,18 @@ export default function MusicDetailPage() {
                                 </Link>
                             )}
                         </div>
+                        {aliasesOpen && aliases.length > 0 && (
+                            <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                                {aliases.map((alias, i) => (
+                                    <span
+                                        key={`${alias}-${i}`}
+                                        className="max-w-full break-words rounded-full bg-slate-100 px-2.5 py-1 text-xs text-slate-600"
+                                    >
+                                        {alias}
+                                    </span>
+                                ))}
+                            </div>
+                        )}
                     </div>
                     <div className="flex items-center gap-3 flex-wrap">
                         <span className="text-slate-600">{music.composer}</span>

--- a/web/src/app/music/client.tsx
+++ b/web/src/app/music/client.tsx
@@ -48,6 +48,17 @@ const MUSIC_SEARCH_FIELDS: FieldRegistry = {
     bpm: makeNumericField("bpm-range", { decimal: false }),
 };
 
+// Collect plain text terms from a parsed query (used to annotate alias hits).
+function collectTextTerms(expr: SearchExpr, out: string[] = []): string[] {
+    if (expr.kind === "term") {
+        if (expr.term.kind === "text") out.push(expr.term.value);
+        return out;
+    }
+    collectTextTerms(expr.left, out);
+    collectTextTerms(expr.right, out);
+    return out;
+}
+
 // Level Separator Card Component
 function LevelSeparatorCard({ level, difficulty }: { level: number; difficulty: string }) {
     const difficultyColors: Record<string, string> = {
@@ -420,6 +431,35 @@ function MusicContent() {
         return result;
     }, [musics, musicTags, eventMusicIds, selectedTag, selectedCategories, hasEventOnly, sortBy, sortOrder, isShowSpoiler, musicDifficultiesMap, selectedDifficulty, songConstantsMap, musicBpmMap, parsedSearch, matchMusicTerm]);
 
+    // musicId -> aliases that explain the current search hit, one per text term
+    // that is not already explained by a visible field (title/translation/credits).
+    const matchedAliasesMap = useMemo(() => {
+        const map = new Map<number, string[]>();
+        if (!parsedSearch) return map;
+        const textTerms = collectTextTerms(parsedSearch)
+            .map(v => v.toLowerCase().trim())
+            .filter(v => v !== "");
+        if (textTerms.length === 0) return map;
+
+        for (const music of filteredMusics) {
+            const hits: string[] = [];
+            for (const q of textTerms) {
+                if (music.title.toLowerCase().includes(q)
+                    || music.composer.toLowerCase().includes(q)
+                    || music.lyricist.toLowerCase().includes(q)
+                    || music.arranger.toLowerCase().includes(q)) continue;
+                const cn = musicCnMap.get(music.id);
+                if (cn && cn.toLowerCase().includes(q)) continue;
+                const en = musicEnMap.get(music.id);
+                if (en && en.toLowerCase().includes(q)) continue;
+                const alias = musicAliasesMap.get(music.id)?.find(a => a.toLowerCase().includes(q));
+                if (alias && !hits.includes(alias)) hits.push(alias);
+            }
+            if (hits.length > 0) map.set(music.id, hits);
+        }
+        return map;
+    }, [filteredMusics, parsedSearch, musicAliasesMap, musicCnMap, musicEnMap]);
+
     // Displayed musics with level separators (only when sorting by level)
     const displayedMusicsWithSeparators = useMemo(() => {
         const musics = filteredMusics.slice(0, displayCount);
@@ -614,7 +654,7 @@ function MusicContent() {
                                 const now = Date.now();
                                 const isSpoiler = music.publishedAt > now;
                                 const musicConstant = showDifficulty ? undefined : songConstantsMap[music.id]?.[selectedDifficulty];
-                                return <MusicItem key={music.id} music={music} isSpoiler={isSpoiler} constant={musicConstant} difficulties={musicDifficultiesMap[music.id]} showDifficulty={showDifficulty} bpm={showBpm ? musicBpmMap.get(music.id)?.bpm : undefined} cnTitle={musicCnMap.get(music.id)} enTitle={musicEnMap.get(music.id)} />;
+                                return <MusicItem key={music.id} music={music} isSpoiler={isSpoiler} constant={musicConstant} difficulties={musicDifficultiesMap[music.id]} showDifficulty={showDifficulty} bpm={showBpm ? musicBpmMap.get(music.id)?.bpm : undefined} cnTitle={musicCnMap.get(music.id)} enTitle={musicEnMap.get(music.id)} matchedAliases={matchedAliasesMap.get(music.id)} />;
                             }
                         })}
                     </div>

--- a/web/src/components/music/MusicItem.tsx
+++ b/web/src/components/music/MusicItem.tsx
@@ -23,9 +23,11 @@ interface MusicItemProps {
     href?: string;
     hrefBase?: string;
     jacketTopLeftLabel?: string;
+    /** Aliases that caused the current search hit (one per text term not explained by title/credits) */
+    matchedAliases?: string[];
 }
 
-export default function MusicItem({ music, isSpoiler, constant, difficulties, showDifficulty, bpm, cnTitle, enTitle, href, hrefBase = "/music", jacketTopLeftLabel }: MusicItemProps) {
+export default function MusicItem({ music, isSpoiler, constant, difficulties, showDifficulty, bpm, cnTitle, enTitle, href, hrefBase = "/music", jacketTopLeftLabel, matchedAliases }: MusicItemProps) {
     const { assetSource, useLLMTranslation } = useTheme();
     const { locale, t } = useI18n();
     const { t: translateMasterText } = useTranslation();
@@ -131,6 +133,27 @@ export default function MusicItem({ music, isSpoiler, constant, difficulties, sh
                         {music.composer}
                         {music.composer !== music.arranger && music.arranger !== "-" && ` / ${music.arranger}`}
                     </p>
+                    {matchedAliases && matchedAliases.length > 0 && (
+                        <div className="mt-1.5 flex flex-wrap items-center gap-1 text-[11px] leading-4">
+                            <svg
+                                className="h-3 w-3 shrink-0 text-miku"
+                                fill="none" viewBox="0 0 24 24" stroke="currentColor"
+                                aria-hidden="true"
+                            >
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                            </svg>
+                            <span className="shrink-0 text-slate-500 dark:text-slate-400">{t("page.music.aliasesLabel")}</span>
+                            {matchedAliases.map((alias) => (
+                                <span
+                                    key={alias}
+                                    className="max-w-full truncate rounded-full bg-miku/10 px-1.5 py-0.5 font-bold text-miku"
+                                    title={alias}
+                                >
+                                    {alias}
+                                </span>
+                            ))}
+                        </div>
+                    )}
                     {showDifficulty && difficulties && (
                         <div className="flex justify-center gap-1 mt-1.5">
                             {ALL_DIFFICULTIES.map(diff => {

--- a/web/src/lib/i18n/messages/en-US/index.ts
+++ b/web/src/lib/i18n/messages/en-US/index.ts
@@ -1575,6 +1575,8 @@ export const enUSMessages = {
             openChartImagePreview: "Open {difficulty} chart image preview",
             open3dChartPreview: "Online 3D Chart Preview",
             bpmListToggle: "Expand / collapse BPM list",
+            aliasesLabel: "Aliases",
+            aliasesToggle: "Expand / collapse aliases",
             vocalVersions: "Vocal versions (skipped {seconds}s intro silence)",
             downloadAudio: "Download audio",
             relatedEvents: "Related Events",

--- a/web/src/lib/i18n/messages/ja-JP/index.ts
+++ b/web/src/lib/i18n/messages/ja-JP/index.ts
@@ -1574,6 +1574,8 @@ export const jaJPMessages = {
       openChartImagePreview: 'Open {difficulty} chart image preview',
       open3dChartPreview: 'Online 3D Chart Preview',
       bpmListToggle: 'BPM リストの展開 / 折りたたみ',
+      aliasesLabel: '別名',
+      aliasesToggle: '別名の展開 / 折りたたみ',
       vocalVersions: 'Vocal versions (skipped {seconds}s intro silence)',
       downloadAudio: 'Download audio',
       relatedEvents: 'Related Events',

--- a/web/src/lib/i18n/messages/ko-KR/index.ts
+++ b/web/src/lib/i18n/messages/ko-KR/index.ts
@@ -1572,6 +1572,8 @@ export const koKRMessages = {
             openChartImagePreview: "{difficulty} 차트 이미지 미리보기 열기",
             open3dChartPreview: "온라인 3D 비트맵 미리보기",
             bpmListToggle: "BPM 목록 펼치기/접기",
+            aliasesLabel: "별칭",
+            aliasesToggle: "별칭 펼치기/접기",
             vocalVersions: "노래하는 버전({seconds}초의 공백 생략)",
             downloadAudio: "오디오 다운로드",
             relatedEvents: "관련 활동",

--- a/web/src/lib/i18n/messages/zh-CN/index.ts
+++ b/web/src/lib/i18n/messages/zh-CN/index.ts
@@ -1574,6 +1574,8 @@ export const zhCNMessages = {
             openChartImagePreview: "打开 {difficulty} 谱面图片预览",
             open3dChartPreview: "在线 3D 谱面预览",
             bpmListToggle: "展开/收起 BPM 列表",
+            aliasesLabel: "别名",
+            aliasesToggle: "展开/收起别名",
             vocalVersions: "演唱版本（已跳过{seconds}秒空白）",
             downloadAudio: "下载音频",
             relatedEvents: "相关活动",

--- a/web/src/lib/i18n/messages/zh-TW/page-primary.ts
+++ b/web/src/lib/i18n/messages/zh-TW/page-primary.ts
@@ -704,6 +704,8 @@ export const zhTWPagePrimary = {
             openChartImagePreview: "打開 {difficulty} 譜面圖片預覽",
             open3dChartPreview: "在線 3D 譜面預覽",
             bpmListToggle: "展開/收起 BPM 列表",
+            aliasesLabel: "別名",
+            aliasesToggle: "展開/收起別名",
             vocalVersions: "演唱版本（已略過{seconds}秒空白）",
             downloadAudio: "下載音訊",
             relatedEvents: "相關活動",


### PR DESCRIPTION
- 音乐详情页标题旁新增「别名」展开按钮（交互同 BPM），展开后以 chips 显示全部别名
- 音乐列表搜索命中别名时，卡片显示命中的别名 chips；AND 多词项逐词显示各自命中的别名，命中同一别名时去重
- 词项已命中标题/译名/作者等可见字段时不显示提示
- 语言包新增 page.music.aliasesLabel / aliasesToggle（zh-CN/zh-TW/en-US/ja-JP/ko-KR）