### PR TITLE
fix(deck): 修好指定队长与模拟活动的参数下发

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
       "name": "moesekai",
       "version": "0.1.0",
       "dependencies": {
-        "@empty-sekai/allium-deck-wasm": "0.0.11",
+        "@empty-sekai/allium-deck-wasm": "0.0.12",
         "@supabase/supabase-js": "2.106.0",
         "@swc/helpers": "^0.5.15",
         "@types/qrcode": "^1.5.6",
@@ -176,7 +176,7 @@
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "https://registry.npmmirror.com/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
-    "@empty-sekai/allium-deck-wasm": ["@empty-sekai/allium-deck-wasm@0.0.11", "https://registry.npmmirror.com/@empty-sekai/allium-deck-wasm/-/allium-deck-wasm-0.0.11.tgz", {}, "sha512-p1XRMwEKsJSdTrnEM+1FO3u+/tkOq9vtBkF4LHP6TFQQk+U9gLaYdEf3wJCVEjCkS5Q3j6Hy/OUAUNdK392WkA=="],
+    "@empty-sekai/allium-deck-wasm": ["@empty-sekai/allium-deck-wasm@0.0.12", "https://registry.npmmirror.com/@empty-sekai/allium-deck-wasm/-/allium-deck-wasm-0.0.12.tgz", {}, "sha512-r/AwWYIacv3paonZoDoUwWyNpelMLmtHwJXvtvh7VeNLnhFFHvgwKpDCP4oO/VbTC8ajPgpRjF/SumGD5WdzIA=="],
 
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "https://registry.npmmirror.com/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12190,7 +12190,7 @@
             "name": "moesekai",
             "version": "0.1.0",
             "dependencies": {
-                "@empty-sekai/allium-deck-wasm": "0.0.11",
+                "@empty-sekai/allium-deck-wasm": "0.0.12",
                 "@supabase/supabase-js": "2.106.0",
                 "@swc/helpers": "^0.5.15",
                 "@types/qrcode": "^1.5.6",
@@ -12231,9 +12231,9 @@
             }
         },
         "web/node_modules/@empty-sekai/allium-deck-wasm": {
-            "version": "0.0.10",
-            "resolved": "https://registry.npmjs.org/@empty-sekai/allium-deck-wasm/-/allium-deck-wasm-0.0.10.tgz",
-            "integrity": "sha512-gdCn0KtL9QSAQZ4z/BhSGGtHBcrQ6QAftKZ0rlBfEo9cOvf8G7/e6tuLHQ7zU9uO46fB1IoM6I0XJWu2eI0Tuw==",
+            "version": "0.0.12",
+            "resolved": "https://registry.npmjs.org/@empty-sekai/allium-deck-wasm/-/allium-deck-wasm-0.0.12.tgz",
+            "integrity": "sha512-r/AwWYIacv3paonZoDoUwWyNpelMLmtHwJXvtvh7VeNLnhFFHvgwKpDCP4oO/VbTC8ajPgpRjF/SumGD5WdzIA==",
             "license": "MIT OR Apache-2.0"
         },
         "web/node_modules/@img/sharp-darwin-arm64": {

--- a/web/package.json
+++ b/web/package.json
@@ -18,7 +18,7 @@
     "test:ssr-localized-links": "npm run build:next && node scripts/check-localized-link-ssr.mjs"
   },
   "dependencies": {
-    "@empty-sekai/allium-deck-wasm": "0.0.11",
+    "@empty-sekai/allium-deck-wasm": "0.0.12",
     "@supabase/supabase-js": "2.106.0",
     "@swc/helpers": "^0.5.15",
     "@types/qrcode": "^1.5.6",

--- a/web/package.json
+++ b/web/package.json
@@ -8,6 +8,7 @@
     "build:next": "next build",
     "copy:wasm": "node scripts/copy-wasm-artifacts.mjs",
     "test:deck-params": "node --experimental-strip-types scripts/test-deck-engine-params.mjs",
+    "test:deck-payload": "node --experimental-strip-types scripts/test-deck-payload.mjs",
     "sitemap": "node scripts/generate-sitemaps.mjs",
     "generate:metadata": "node scripts/generate-metadata-map.mjs",
     "start": "next start",

--- a/web/scripts/copy-wasm-artifacts.mjs
+++ b/web/scripts/copy-wasm-artifacts.mjs
@@ -1,9 +1,13 @@
 /**
  * WASM Deck Engine Artifact Copier
  *
- * 把 npm 包 @empty-sekai/allium-deck-wasm 的产物拷贝到 public/wasm/，
+ * 把 @empty-sekai/allium-deck-wasm 的产物拷贝到 public/wasm/，
  * 让浏览器在运行时直接从 /wasm/ 加载，而不经过打包器。
- * 产物只来自已安装的 npm 包；先 `npm install` 再跑本脚本。
+ * 默认取已安装的 npm 包；先 `npm install` 再跑本脚本。
+ *
+ * ALLIUM_DECK_WASM_DIR 可指向本地 `wasm-pack build wasm --target web` 的产物目录
+ * （形如 <allium-deck>/wasm/pkg），用来联调尚未发版的引擎改动——否则每次
+ * `npm run dev` / `npm run build` 都会用 npm 包覆盖本地构建。
  *
  * 同时生成 src/lib/deck-engine/wasm-version.ts，供加载器做缓存击穿。
  *
@@ -32,6 +36,15 @@ const OUT_DIR = path.join(webRoot, 'public', 'wasm');
 const VERSION_FILE = path.join(webRoot, 'src', 'lib', 'deck-engine', 'wasm-version.ts');
 
 function resolvePackageDir() {
+    // 显式指定的本地构建目录优先：联调未发版引擎时用它。
+    const local = process.env.ALLIUM_DECK_WASM_DIR;
+    if (local) {
+        const dir = path.resolve(local);
+        if (!fs.existsSync(path.join(dir, 'allium_deck.js'))) {
+            throw new Error(`ALLIUM_DECK_WASM_DIR 里没有 allium_deck.js: ${dir}`);
+        }
+        return dir;
+    }
     // workspaces 会把依赖提升到仓库根 node_modules，所以用 require.resolve 而不是拼路径。
     const require = createRequire(import.meta.url);
     const entry = require.resolve(`${PACKAGE_NAME}/allium_deck.js`, {
@@ -44,9 +57,11 @@ function main() {
     let packageDir;
     try {
         packageDir = resolvePackageDir();
-    } catch {
+    } catch (err) {
         console.error(
-            `[copy-wasm] 找不到 ${PACKAGE_NAME}。先跑 npm install。`,
+            process.env.ALLIUM_DECK_WASM_DIR
+                ? `[copy-wasm] ${err.message}`
+                : `[copy-wasm] 找不到 ${PACKAGE_NAME}。先跑 npm install。`,
         );
         process.exit(1);
     }
@@ -75,8 +90,9 @@ function main() {
         'utf8',
     );
 
+    const source = process.env.ALLIUM_DECK_WASM_DIR ? `本地构建 ${packageDir}` : PACKAGE_NAME;
     console.log(
-        `[copy-wasm] ${PACKAGE_NAME}@${pkg.version} → public/wasm/ (${ARTIFACTS.map(([, out]) => out).join(', ')})`,
+        `[copy-wasm] ${source}@${pkg.version} → public/wasm/ (${ARTIFACTS.map(([, out]) => out).join(', ')})`,
     );
 }
 

--- a/web/scripts/scan-hardcoded-ui-text.mjs
+++ b/web/scripts/scan-hardcoded-ui-text.mjs
@@ -40,6 +40,8 @@ const COMMENT_ONLY_ALLOWLIST = new Map([
     ["src/app/deck-recommend/client.tsx", "Comments describing deck recommendation page internals"],
     ["src/lib/deck-recommend/engine-worker.ts", "Comments describing deck engine worker internals"],
     ["src/lib/deck-recommend/engine-types.ts", "Comments describing deck engine worker contract"],
+    ["src/lib/deck-recommend/engine-options.ts", "Comments describing the engine option mapping"],
+    ["src/lib/deck-recommend/worker-args.ts", "Comments describing the deck worker argument mapping"],
     ["src/components/deck-recommend/CardPickerModal.tsx", "Comments describing the deck card picker internals"],
     ["src/lib/deck-engine/wasm-version.ts", "Generated file header comment"],
 ]);

--- a/web/scripts/test-deck-engine-params.mjs
+++ b/web/scripts/test-deck-engine-params.mjs
@@ -54,6 +54,13 @@ const BASE_EVENT = {
     ...ALL_RARITY_DEFAULTS,
 };
 
+/** 模拟活动基线：与 BASE_EVENT 同口径，但刻意不带 event_id。 */
+const SIM_BASE = {
+    region: 'jp', live_type: 'multi', music_id: 74, music_diff: 'master',
+    target: 'score', limit: 3, timeout_ms: 60_000,
+    ...ALL_RARITY_DEFAULTS,
+};
+
 const BASE_MUSIC_DECK = (deck) => ({
     total_power: deck.total_power,
     event_bonus_rate: deck.event_bonus_total ?? 0,
@@ -66,6 +73,10 @@ function buildMatrix(mod, decks, ctx) {
     const deck0 = decks[0];
     const topCard = deck0.cards[0].card_id;
     const secondCard = deck0.cards[1].card_id;
+    // 固定住基线里本来占队长位的那张卡，再把队长指定给队尾角色。
+    // 这样「指定队长没生效」会直接暴露成队长位仍是固定卡。
+    const otherCharCard = deck0.cards[0].card_id;
+    const leaderChar = deck0.cards[deck0.cards.length - 1].character_id;
     const { basePoolSize, baseWlBonus } = ctx;
     return [
         {
@@ -212,6 +223,47 @@ function buildMatrix(mod, decks, ctx) {
             patch: { custom_bonus_attr: 'cool' },
             assert: (r) => r.decks.length > 0,
             expect: '自定义加成属性被接受',
+        },
+        {
+            name: 'forcedLeaderCharacterId',
+            base: BASE_EVENT, patch: { forced_leader_character_id: 1 },
+            assert: (r) => r.decks.length > 0 && r.decks.every((d) => d.cards[0].character_id === 1),
+            expect: '指定队长后每个卡组的队长位都是该角色',
+        },
+        {
+            name: 'forcedLeaderCharacterId + fixedCards',
+            base: { ...BASE_EVENT, fixedCards: [otherCharCard] },
+            patch: { forced_leader_character_id: leaderChar },
+            assert: (r) => r.decks.length > 0
+                && r.decks.every((d) => d.cards[0].character_id === leaderChar)
+                && r.decks.every((d) => d.cards.some((c) => c.card_id === otherCharCard)),
+            expect: `固定卡 ${otherCharCard} 留在队里，队长位仍是指定的角色 ${leaderChar}`,
+        },
+        {
+            name: 'simulated unit event',
+            base: SIM_BASE, patch: { event_type: 'marathon', event_unit: 'idol' },
+            assert: (r) => r.decks.length > 0 && (r.decks[0].event_bonus_total ?? 0) > 0,
+            expect: '模拟团活按团给出加成',
+        },
+        {
+            name: 'simulated mixed event',
+            base: SIM_BASE,
+            patch: { event_type: 'marathon', custom_bonus_character_ids: [1, 5, 10, 15, 21], custom_bonus_character_support_units: { 21: 'street' } },
+            assert: (r) => r.decks.length > 0 && (r.decks[0].event_bonus_total ?? 0) > 0,
+            expect: '模拟混活按角色集合给出加成',
+        },
+        {
+            name: 'simulated cheerful carnival',
+            base: { ...SIM_BASE, live_type: 'cheerful' },
+            patch: { event_type: 'cheerful_carnival', event_unit: 'idol', event_attr: 'happy' },
+            assert: (r) => r.decks.length > 0 && (r.decks[0].event_point ?? 0) > 0,
+            expect: '模拟 5v5 算出活动 PT',
+        },
+        {
+            name: 'simulated world bloom turn 1/2',
+            base: SIM_BASE, patch: { event_type: 'world_bloom', world_bloom_event_turn: 1, event_unit: 'street' },
+            assert: (r) => r.decks.length > 0 && (r.decks[0].event_bonus_total ?? 0) > 0,
+            expect: '模拟连接世界第 1 轮不再要求真实活动 ID',
         },
         {
             name: 'recommendMusic（单曲收益）',
@@ -527,7 +579,11 @@ console.log('3C) 展示解码逐模式校验…');
     handle.free();
 
     console.log('\nB) worker 选项键静态对照…');
-    const workerSource = readFileSync(resolve(webRoot, 'src/lib/deck-recommend/engine-worker.ts'), 'utf8');
+    // 引擎 options 的组装已抽到 engine-options.ts；worker 只剩数据加载与句柄复用。
+    const workerSource = [
+        readFileSync(resolve(webRoot, 'src/lib/deck-recommend/engine-options.ts'), 'utf8'),
+        readFileSync(resolve(webRoot, 'src/lib/deck-recommend/engine-worker.ts'), 'utf8'),
+    ].join('\n');
     const requiredKeys = [
         'event_id', 'event_type', 'event_attr', 'event_unit', 'world_bloom_event_turn',
         'world_bloom_character_id', 'challenge_live_character_id', 'target', 'limit', 'timeout_ms',
@@ -550,21 +606,28 @@ console.log('3C) 展示解码逐模式校验…');
         console.error(`   ✗ worker 缺少键: ${missing.join(', ')}`);
     }
 
-    console.log('B2) client → worker 覆盖传参静态对照…');
+    // 表单 → worker 入参那一层的逐字段断言在 scripts/test-deck-payload.mjs，
+    // 这里只做一次粗筛，保证页面还在走那个纯映射、没有绕回手写 payload。
+    console.log('B2) client → worker 传参入口静态对照…');
     const clientSource = readFileSync(resolve(webRoot, 'src/app/deck-recommend/client.tsx'), 'utf8');
-    const clientKeys = [
-        'DataOverridePanel', 'areaItemLevel', 'areaItemOverrides',
-        'characterRank', 'characterRankOverrides', 'mysekaiGateLevel', 'mysekaiGateOverrides',
-        'mysekaiFixtureBonusRate', 'mysekaiFixtureOverrides',
-        'characterFilterIds', 'useCurrentDeck', 'unitFilter', 'attrFilter',
+    const argsSource = readFileSync(resolve(webRoot, 'src/lib/deck-recommend/worker-args.ts'), 'utf8');
+    const clientKeys = ['buildDeckWorkerArgs', 'DataOverridePanel', 'useCurrentDeck'];
+    const argsKeys = [
+        'simulatedEvent', 'userDataOverrides', 'leaderCharacterId',
+        'areaItemLevel', 'areaItemLevelOverrides', 'characterRank', 'characterRankOverrides',
+        'mysekaiGateLevel', 'mysekaiGateLevelOverrides',
+        'mysekaiFixtureBonusRate', 'mysekaiFixtureBonusRateOverrides',
+        'characterFilterIds', 'unitFilter', 'attrFilter',
+        'simBonusMode', 'simCharacterIds', 'simCharacterUnits',
     ];
-    const clientMissing = clientKeys.filter((key) => !clientSource.includes(key));
+    const clientMissing = clientKeys.filter((key) => !clientSource.includes(key))
+        .concat(argsKeys.filter((key) => !argsSource.includes(key)));
     if (clientMissing.length === 0) {
         pass += 1;
-        console.log(`   ✓ client 传参覆盖 ${clientKeys.length} 个键`);
+        console.log(`   ✓ 页面走 buildDeckWorkerArgs，映射覆盖 ${argsKeys.length} 个契约字段`);
     } else {
         failures.push(`client missing keys: ${clientMissing.join(', ')}`);
-        console.error(`   ✗ client 缺少键: ${clientMissing.join(', ')}`);
+        console.error(`   ✗ 缺少键: ${clientMissing.join(', ')}`);
     }
 
     console.log(`\n参数全量验证：${pass} 项通过${failures.length ? `，${failures.length} 项失败：${failures.join('; ')}` : '，全部生效'}`);

--- a/web/scripts/test-deck-payload.mjs
+++ b/web/scripts/test-deck-payload.mjs
@@ -1,0 +1,396 @@
+/**
+ * 组卡参数映射测试（Node，不进构建，不联网）。
+ *
+ * 盯的是两层纯映射：
+ *   表单状态 --buildDeckWorkerArgs--> worker 入参 --buildEngineOptions--> 引擎 options
+ *
+ * 这一层丢字段不会抛错，只会静默退化成另一种搜索——模拟活动退回真实活动、
+ * 指定队长被忽略、进阶覆盖被丢掉——所以每个字段都要有断言直接盯住落点。
+ *
+ * 使用方法: node --experimental-strip-types scripts/test-deck-payload.mjs
+ */
+
+import { resolve } from 'path';
+import { pathToFileURL } from 'url';
+
+const webRoot = resolve(import.meta.dirname ?? '.', '..');
+const load = (rel) => import(pathToFileURL(resolve(webRoot, rel)).href);
+
+const { buildDeckWorkerArgs, DEFAULT_DECK_FORM_STATE } = await load('src/lib/deck-recommend/worker-args.ts');
+const { buildEngineOptions } = await load('src/lib/deck-recommend/engine-options.ts');
+
+const EVENT_ROWS = [
+    { id: 200, eventType: 'marathon' },
+    { id: 201, eventType: 'cheerful_carnival' },
+    { id: 202, eventType: 'world_bloom' },
+];
+const WL3_SIM_EVENT_IDS = [3200001, 3200002, 3200003, 3200004, 3200005];
+
+const ACCOUNT = { server: 'jp', userId: ' 1234567890 ', bonusTargets: null };
+
+/** 表单状态 → worker 入参 → 引擎 options。 */
+function pipeline(patch, account = ACCOUNT) {
+    const state = { ...DEFAULT_DECK_FORM_STATE, ...patch };
+    const args = buildDeckWorkerArgs(state, account);
+    const options = buildEngineOptions(args, {
+        eventRows: EVENT_ROWS,
+        wl3SimulationEventIds: WL3_SIM_EVENT_IDS,
+    });
+    return { state, args, options };
+}
+
+let pass = 0;
+const failures = [];
+
+function check(name, fn) {
+    try {
+        const problem = fn();
+        if (problem) {
+            failures.push(`${name}: ${problem}`);
+            console.error(`   ✗ ${name} — ${problem}`);
+        } else {
+            pass += 1;
+            console.log(`   ✓ ${name}`);
+        }
+    } catch (err) {
+        failures.push(`${name}: ${err.message}`);
+        console.error(`   ✗ ${name} — 抛异常: ${err.message}`);
+    }
+}
+
+const eq = (actual, expected, label) =>
+    JSON.stringify(actual) === JSON.stringify(expected)
+        ? null
+        : `${label} 期望 ${JSON.stringify(expected)}，实际 ${JSON.stringify(actual)}`;
+
+// ==================== 账号与通用字段 ====================
+console.log('A) 账号与通用字段');
+
+const ARGS_BASE = { mode: 'event', eventId: '200', musicId: '74' };
+
+check('userId 去空格、server 透传', () => {
+    const { args } = pipeline(ARGS_BASE);
+    return eq(args.userId, '1234567890', 'userId') ?? eq(args.server, 'jp', 'server');
+});
+
+check('limit / timeout 有边界钳制', () => {
+    const high = pipeline({ ...ARGS_BASE, limit: '999', timeoutSeconds: '9999' }).args;
+    // 0 / 空串按「没填」处理，回落默认条数；超时另有 5 秒下限。
+    const low = pipeline({ ...ARGS_BASE, limit: '0', timeoutSeconds: '1' }).args;
+    const one = pipeline({ ...ARGS_BASE, limit: '1' }).args;
+    return eq(high.limit, 30, 'limit 上限')
+        ?? eq(high.timeoutMs, 300_000, 'timeoutMs 上限')
+        ?? eq(low.limit, 10, 'limit=0 回落默认')
+        ?? eq(one.limit, 1, 'limit 下限')
+        ?? eq(low.timeoutMs, 5_000, 'timeoutMs 下限');
+});
+
+// ==================== 真实活动 ====================
+console.log('B) 真实活动');
+
+check('活动模式下发 event_id 与目标', () => {
+    const { options } = pipeline({ mode: 'event', eventId: '200', selectedEventType: 'marathon', musicId: '74' });
+    return eq(options.event_id, 200, 'event_id')
+        ?? eq(options.target, 'score', 'target')
+        ?? eq(options.live_type, 'multi', 'live_type')
+        ?? eq(options.music_id, 74, 'music_id');
+});
+
+check('混战活动把 multi 换成 cheerful', () => {
+    const { options } = pipeline({ mode: 'event', eventId: '201', selectedEventType: 'cheerful_carnival', musicId: '74' });
+    return eq(options.live_type, 'cheerful', 'live_type');
+});
+
+check('连接世界真实活动带章节角色', () => {
+    const { options } = pipeline({
+        mode: 'event', eventId: '202', selectedEventType: 'world_bloom',
+        supportCharacterId: 5, musicId: '74',
+    });
+    return eq(options.event_id, 202, 'event_id')
+        ?? eq(options.world_bloom_character_id, 5, 'world_bloom_character_id');
+});
+
+check('EventSelector 的 WL3 假活动转成模拟参数且不带 event_id', () => {
+    const { options } = pipeline({
+        mode: 'event', eventId: '3200003', selectedEventType: 'world_bloom',
+        supportCharacterId: 9, musicId: '74',
+    });
+    return eq(options.event_id, undefined, 'event_id')
+        ?? eq(options.world_bloom_event_turn, 3, 'world_bloom_event_turn')
+        ?? eq(options.world_bloom_character_id, 9, 'world_bloom_character_id');
+});
+
+check('目标加成档位下发', () => {
+    const { options } = pipeline(
+        { mode: 'event', eventId: '200', selectedEventType: 'marathon', musicId: '74', target: 'bonus' },
+        { ...ACCOUNT, bonusTargets: [420, 425] },
+    );
+    return eq(options.target, 'bonus', 'target') ?? eq(options.target_bonus_list, [420, 425], 'target_bonus_list');
+});
+
+// ==================== 模拟活动 ====================
+console.log('C) 模拟活动（团活 / 混活 / 连接世界）');
+
+const SIM_BASE = { mode: 'event', simulateEnabled: true, musicId: '74' };
+
+check('模拟开启后 worker 一定拿到 simulatedEvent', () => {
+    const { args } = pipeline({ ...SIM_BASE, simType: 'marathon' });
+    return args.simulatedEvent ? null : 'simulatedEvent 缺失——worker 会退回真实活动分支';
+});
+
+check('模拟活动即使页面残留 eventId 也不下发 event_id', () => {
+    // 回归点：残留的 eventId 会让引擎按真实活动算，模拟条件全部失效。
+    const { options } = pipeline({ ...SIM_BASE, eventId: '200', selectedEventType: 'marathon', simType: 'marathon' });
+    return eq(options.event_id, undefined, 'event_id') ?? eq(options.event_type, 'marathon', 'event_type');
+});
+
+check('未选活动且未开模拟时才报缺 ID', () => {
+    // 回归点：以前模拟开关不生效，没选活动就抛 "event mode requires eventId"。
+    let simulatedThrew = false;
+    try {
+        pipeline({ ...SIM_BASE, simType: 'marathon' });
+    } catch {
+        simulatedThrew = true;
+    }
+    let realThrew = false;
+    try {
+        pipeline({ mode: 'event', musicId: '74' });
+    } catch {
+        realThrew = true;
+    }
+    if (simulatedThrew) return '开了模拟仍报缺 ID';
+    if (!realThrew) return '没选活动也没开模拟时应当报缺 ID';
+    return null;
+});
+
+check('模拟团活：下发 event_unit', () => {
+    const { options } = pipeline({
+        ...SIM_BASE, simType: 'marathon', simBonusMode: 'unit', simUnit: 'light_sound', simAttr: 'cool',
+    });
+    return eq(options.event_type, 'marathon', 'event_type')
+        ?? eq(options.event_unit, 'light_sound', 'event_unit')
+        ?? eq(options.event_attr, 'cool', 'event_attr')
+        ?? eq(options.custom_bonus_character_ids, undefined, 'custom_bonus_character_ids');
+});
+
+check('模拟混活：下发加成角色集合与 VS 支援团', () => {
+    const { options } = pipeline({
+        ...SIM_BASE, simType: 'marathon', simBonusMode: 'character',
+        simCharacterIds: [1, 5, 21], simCharacterUnits: { 21: 'street' }, simAttr: 'cute',
+    });
+    return eq(options.custom_bonus_character_ids, [1, 5, 21], 'custom_bonus_character_ids')
+        ?? eq(options.custom_bonus_character_support_units, { 21: 'street' }, 'custom_bonus_character_support_units')
+        ?? eq(options.event_attr, 'cute', 'event_attr')
+        ?? eq(options.event_unit, undefined, 'event_unit 不应与角色集合同时下发');
+});
+
+check('模拟混战：event_type 与 live_type 都是 cheerful 口径', () => {
+    const { options } = pipeline({
+        ...SIM_BASE, simType: 'cheerful_carnival', simBonusMode: 'unit', simUnit: 'idol', simAttr: 'happy',
+    });
+    return eq(options.event_type, 'cheerful_carnival', 'event_type')
+        ?? eq(options.live_type, 'cheerful', 'live_type')
+        ?? eq(options.event_unit, 'idol', 'event_unit');
+});
+
+for (const turn of [1, 2]) {
+    check(`模拟连接世界第 ${turn} 轮：按团下发轮次`, () => {
+        const { options } = pipeline({
+            ...SIM_BASE, simType: 'world_bloom', simTurn: turn, simUnit: 'street',
+        });
+        return eq(options.event_type, 'world_bloom', 'event_type')
+            ?? eq(options.world_bloom_event_turn, turn, 'world_bloom_event_turn')
+            ?? eq(options.event_unit, 'street', 'event_unit')
+            ?? eq(options.world_bloom_character_id, undefined, 'world_bloom_character_id');
+    });
+}
+
+check('模拟连接世界第 3 轮：按章节角色下发', () => {
+    const { options } = pipeline({
+        ...SIM_BASE, simType: 'world_bloom', simTurn: 3, simCharacterId: 21, simUnit: 'street',
+    });
+    return eq(options.world_bloom_event_turn, 3, 'world_bloom_event_turn')
+        ?? eq(options.world_bloom_character_id, 21, 'world_bloom_character_id')
+        ?? eq(options.event_unit, undefined, '第 3 轮按角色分组，不该带 event_unit');
+});
+
+check('连接世界模拟不吃属性加成', () => {
+    const { options } = pipeline({
+        ...SIM_BASE, simType: 'world_bloom', simTurn: 3, simCharacterId: 21, simAttr: 'cool',
+    });
+    return eq(options.event_attr, undefined, 'event_attr');
+});
+
+// ==================== 指定队长 ====================
+console.log('D) 指定队长（与固定卡共存时队长位归指定角色）');
+
+check('指定队长下发 forced_leader_character_id', () => {
+    const { options } = pipeline({
+        mode: 'event', eventId: '200', selectedEventType: 'marathon', musicId: '74', leaderCharacterId: 7,
+    });
+    return eq(options.forced_leader_character_id, 7, 'forced_leader_character_id');
+});
+
+check('固定卡与指定队长同时下发', () => {
+    const { options } = pipeline({
+        mode: 'event', eventId: '200', selectedEventType: 'marathon', musicId: '74',
+        fixedCards: [1004], leaderCharacterId: 26,
+    });
+    return eq(options.fixedCards, [1004], 'fixedCards')
+        ?? eq(options.forced_leader_character_id, 26, 'forced_leader_character_id');
+});
+
+check('未指定队长时不下发该键', () => {
+    const { options } = pipeline({ mode: 'event', eventId: '200', selectedEventType: 'marathon', musicId: '74' });
+    return eq(options.forced_leader_character_id, undefined, 'forced_leader_character_id');
+});
+
+check('最高技能作队长的开关按原样透传', () => {
+    const on = pipeline({ mode: 'event', eventId: '200', musicId: '74', bestSkillAsLeader: true }).options;
+    const off = pipeline({ mode: 'event', eventId: '200', musicId: '74', bestSkillAsLeader: false }).options;
+    return eq(on.bestSkillAsLeader, undefined, '默认开启时不必下发')
+        ?? eq(off.bestSkillAsLeader, false, '关闭时必须下发 false');
+});
+
+// ==================== 进阶数据覆盖 ====================
+console.log('E) 进阶数据覆盖');
+
+check('userDataOverrides 打包成对象且键名与 worker 契约一致', () => {
+    const { args } = pipeline({
+        mode: 'event', eventId: '200', musicId: '74',
+        areaItemLevel: '15', characterRank: '50', mysekaiGateLevel: '3', mysekaiFixtureBonusRate: '120',
+        areaItemOverrides: [{ areaItemId: 1, level: 10 }],
+        characterRankOverrides: [{ characterId: 1, rank: 1 }],
+        mysekaiGateOverrides: [{ mysekaiGateId: 1, level: 2 }],
+        mysekaiFixtureOverrides: [{ characterId: 1, totalBonusRate: 0 }],
+    });
+    const o = args.userDataOverrides;
+    if (!o) return 'userDataOverrides 缺失';
+    return eq(o.areaItemLevel, 15, 'areaItemLevel')
+        ?? eq(o.characterRank, 50, 'characterRank')
+        ?? eq(o.mysekaiGateLevel, 3, 'mysekaiGateLevel')
+        ?? eq(o.mysekaiFixtureBonusRate, 120, 'mysekaiFixtureBonusRate')
+        ?? eq(o.areaItemLevelOverrides?.length, 1, 'areaItemLevelOverrides')
+        ?? eq(o.characterRankOverrides?.length, 1, 'characterRankOverrides')
+        ?? eq(o.mysekaiGateLevelOverrides?.length, 1, 'mysekaiGateLevelOverrides')
+        ?? eq(o.mysekaiFixtureBonusRateOverrides?.length, 1, 'mysekaiFixtureBonusRateOverrides');
+});
+
+check('空覆盖表现为全 null，不会被误判成有效覆盖', () => {
+    const o = pipeline({ mode: 'event', eventId: '200', musicId: '74' }).args.userDataOverrides;
+    return eq(
+        [o.areaItemLevel, o.characterRank, o.mysekaiGateLevel, o.mysekaiFixtureBonusRate],
+        [null, null, null, null],
+        '统一值',
+    );
+});
+
+check('最弱组卡不带任何覆盖', () => {
+    const { args, options } = pipeline({ mode: 'weakest', areaItemLevel: '15', characterRank: '50' });
+    return eq(args.userDataOverrides, undefined, 'userDataOverrides')
+        ?? eq(options.target, 'power', 'target')
+        ?? eq(options.minimize, true, 'minimize')
+        ?? eq(options.live_type, 'solo', 'live_type')
+        ?? eq(options.music_id, undefined, 'music_id');
+});
+
+check('角色过滤单独下发', () => {
+    const { args } = pipeline({ mode: 'event', eventId: '200', musicId: '74', characterFilterIds: [1, 2] });
+    return eq(args.characterFilterIds, [1, 2], 'characterFilterIds');
+});
+
+// ==================== 其他模式 ====================
+console.log('F) 其他模式');
+
+check('挑战模式：角色 + challenge live 类型', () => {
+    const normal = pipeline({ mode: 'challenge', challengeCharacterId: 4, liveType: 'challenge', musicId: '74' }).options;
+    const auto = pipeline({ mode: 'challenge', challengeCharacterId: 4, liveType: 'auto', musicId: '74' }).options;
+    return eq(normal.challenge_live_character_id, 4, 'challenge_live_character_id')
+        ?? eq(normal.live_type, 'challenge', 'live_type')
+        ?? eq(auto.live_type, 'challenge_auto', 'auto live_type');
+});
+
+check('自定义加成模式：按团 / 按角色两种口径', () => {
+    const unit = pipeline({ mode: 'custom', customSubMode: 'unit', customUnit: 'idol', customAttr: 'cool', musicId: '74' }).options;
+    const chars = pipeline({
+        mode: 'custom', customSubMode: 'character', customCharacterIds: [1, 21],
+        customCharacterUnits: { 21: 'piapro' }, musicId: '74',
+    }).options;
+    return eq(unit.event_unit, 'idol', 'event_unit')
+        ?? eq(unit.custom_bonus_attr, 'cool', 'custom_bonus_attr')
+        ?? eq(chars.custom_bonus_character_ids, [1, 21], 'custom_bonus_character_ids')
+        ?? eq(chars.custom_bonus_character_support_units, { 21: 'piapro' }, 'custom_bonus_character_support_units');
+});
+
+check('最强组卡：综合力 / 技能两个目标', () => {
+    const power = pipeline({ mode: 'strongest', strongestTarget: 'power', musicId: '74' }).options;
+    const skill = pipeline({ mode: 'strongest', strongestTarget: 'skill', musicId: '74' }).options;
+    return eq(power.target, 'power', 'power target') ?? eq(skill.target, 'skill', 'skill target');
+});
+
+check('烤森模式：活动 ID + mysekai 目标，且不要求乐曲', () => {
+    const { options } = pipeline({ mode: 'mysekai', eventId: '200' });
+    return eq(options.event_id, 200, 'event_id')
+        ?? eq(options.target, 'mysekai', 'target')
+        ?? eq(options.music_id, undefined, 'music_id');
+});
+
+check('养成配置逐稀有度下发', () => {
+    const { options } = pipeline({ mode: 'event', eventId: '200', musicId: '74' });
+    return eq(Object.keys(options).filter((k) => k.endsWith('Config')).sort(), [
+        'rarity1Config', 'rarity2Config', 'rarity3Config', 'rarity4Config', 'rarityBirthdayConfig',
+    ], '养成配置键');
+});
+
+check('特定技能顺序从 1-based 换成引擎的 0-based', () => {
+    const { options } = pipeline({
+        mode: 'event', eventId: '200', musicId: '74', skillOrder: 'specific', specificSkillOrder: '15243',
+    });
+    return eq(options.liveSkillOrder, 'specific', 'liveSkillOrder')
+        ?? eq(options.specificSkillOrder, '0,4,1,3,2', 'specificSkillOrder');
+});
+
+check('协力参数与过滤条件透传', () => {
+    const { options } = pipeline({
+        mode: 'event', eventId: '200', musicId: '74',
+        multiTeammatePower: '250000', multiTeammateScoreUp: '400', multiScoreUpLowerBound: '350',
+        boost: '10', otherScore: '1000000', unitFilter: 'idol', attrFilter: 'cool',
+        supportMasterMax: true, supportSkillMax: true, filterOtherUnit: true,
+        keepAfterTrainingState: true, skillReference: 'max',
+        excludedCards: [1], fixedCharacters: [2],
+        singleCardOverrides: [{ cardId: 1, level: 1 }],
+    });
+    return eq(options.multiLiveTeammatePower, 250000, 'multiLiveTeammatePower')
+        ?? eq(options.multiLiveTeammateScoreUp, 400, 'multiLiveTeammateScoreUp')
+        ?? eq(options.multiLiveScoreUpLowerBound, 350, 'multiLiveScoreUpLowerBound')
+        ?? eq(options.boost, 10, 'boost')
+        ?? eq(options.otherScore, 1000000, 'otherScore')
+        ?? eq(options.unitFilter, 'idol', 'unitFilter')
+        ?? eq(options.attrFilter, 'cool', 'attrFilter')
+        ?? eq(options.supportMasterMax, true, 'supportMasterMax')
+        ?? eq(options.supportSkillMax, true, 'supportSkillMax')
+        ?? eq(options.filterOtherUnit, true, 'filterOtherUnit')
+        ?? eq(options.keepAfterTrainingState, true, 'keepAfterTrainingState')
+        ?? eq(options.skillReferenceChooseStrategy, 'max', 'skillReferenceChooseStrategy')
+        ?? eq(options.excludedCards, [1], 'excludedCards')
+        ?? eq(options.fixedCharacters, [2], 'fixedCharacters')
+        ?? eq(options.singleCardConfigs?.length, 1, 'singleCardConfigs');
+});
+
+// ==================== 契约完整性 ====================
+console.log('G) 契约完整性');
+
+check('worker 入参里的成组字段一个都不能少', () => {
+    const { args } = pipeline({
+        ...SIM_BASE, simType: 'marathon', simBonusMode: 'character', simCharacterIds: [1],
+        leaderCharacterId: 3, areaItemLevel: '10',
+    });
+    const missing = ['simulatedEvent', 'userDataOverrides', 'leaderCharacterId']
+        .filter((key) => args[key] === undefined);
+    return missing.length === 0 ? null : `缺少 ${missing.join(', ')}`;
+});
+
+console.log(
+    `\n参数映射测试：${pass} 项通过${failures.length ? `，${failures.length} 项失败：${failures.join('; ')}` : '，全部命中'}`,
+);
+if (failures.length) process.exit(1);

--- a/web/src/app/deck-recommend/client.tsx
+++ b/web/src/app/deck-recommend/client.tsx
@@ -36,21 +36,19 @@ import EventSelector from "@/components/deck-recommend/EventSelector";
 import MusicSelector from "@/components/deck-recommend/MusicSelector";
 import { preloadDeckEngine } from "@/lib/deck-engine/wasm-loader";
 import { type OverrideCatalogItem } from "@/components/deck-recommend/DataOverridePanel";
+import {
+    buildDeckWorkerArgs,
+    DEFAULT_CARD_CONFIG,
+    DEFAULT_DECK_FORM_STATE as DEFAULT_SAVED_CONFIG,
+    type DeckFormState as SavedConfig,
+} from "@/lib/deck-recommend/worker-args";
 import { SnowyDataProvider } from "@/lib/deck-recommend/data-provider";
 import type {
     DeckRecommendMode,
     DeckResultDeck,
-    DeckSingleCardOverride,
     DeckTrainingConfig,
     DeckUserCard,
     DeckWorkerOutput,
-    DeckTarget,
-    DeckSkillOrder,
-    DeckSkillReference,
-    DeckAreaItemOverride,
-    DeckCharacterRankOverride,
-    DeckMysekaiFixtureOverride,
-    DeckMysekaiGateOverride,
 } from "@/lib/deck-recommend/engine-types";
 import "./deck-recommend.css";
 
@@ -284,145 +282,18 @@ const RARITY_CONFIG_KEYS = [
     { key: "rarity_birthday", color: "#FF6699" },
 ];
 
-const DEFAULT_CARD_CONFIG: Record<string, DeckTrainingConfig> = {
-    rarity_1: { disable: false, levelMax: true, episodeRead: true, masterMax: false, skillMax: false },
-    rarity_2: { disable: false, levelMax: true, episodeRead: true, masterMax: false, skillMax: false },
-    rarity_3: { disable: false, levelMax: true, episodeRead: true, masterMax: false, skillMax: false },
-    rarity_4: { disable: false, levelMax: true, episodeRead: true, masterMax: false, skillMax: false },
-    rarity_birthday: { disable: false, levelMax: true, episodeRead: true, masterMax: false, skillMax: false },
-};
 
 const SIM_EVENT_TYPE_OPTIONS = ["marathon", "cheerful_carnival", "world_bloom"] as const;
 
 const VIRTUAL_SINGER_ID_MIN = 21;
 
-type CustomSubMode = "unit" | "character";
 type TranslationFn = ReturnType<typeof useI18n>["t"];
 
 const USER_ID_STORAGE_KEY = "deck_recommend_userid";
 const SERVER_STORAGE_KEY = "deck_recommend_server";
 const SAVED_CONFIG_KEY = "deck_recommend_saved_config_v2";
 
-/** 保存到 localStorage 的可序列化表单状态。 */
-interface SavedConfig {
-    mode: DeckRecommendMode;
-    eventId: string;
-    selectedEventType: string | null;
-    eventBonusCharacterIds: number[];
-    liveType: string;
-    supportCharacterId: number | null;
-    challengeCharacterId: number | null;
-    musicId: string;
-    difficulty: string;
-    cardConfig: Record<string, DeckTrainingConfig>;
-    target: DeckTarget;
-    bonusTargets: string;
-    simulateEnabled: boolean;
-    simType: string;
-    simAttr: string;
-    simUnit: string;
-    simTurn: number;
-    simCharacterId: number | null;
-    customSubMode: CustomSubMode;
-    customUnit: string;
-    customCharacterIds: number[];
-    customCharacterUnits: Record<number, string>;
-    customAttr: string;
-    strongestTarget: "power" | "skill";
-    multiTeammatePower: string;
-    multiTeammateScoreUp: string;
-    multiScoreUpLowerBound: string;
-    skillOrder: DeckSkillOrder;
-    specificSkillOrder: string;
-    skillReference: DeckSkillReference;
-    keepAfterTrainingState: boolean;
-    bestSkillAsLeader: boolean;
-    minimize: boolean;
-    supportMasterMax: boolean;
-    supportSkillMax: boolean;
-    filterOtherUnit: boolean;
-    boost: string;
-    otherScore: string;
-    leaderCharacterId: number | null;
-    fixedCards: number[];
-    fixedCharacters: number[];
-    excludedCards: number[];
-    singleCardOverrides: DeckSingleCardOverride[];
-    areaItemLevel: string;
-    areaItemOverrides: DeckAreaItemOverride[];
-    characterRank: string;
-    characterRankOverrides: DeckCharacterRankOverride[];
-    mysekaiGateLevel: string;
-    mysekaiGateOverrides: DeckMysekaiGateOverride[];
-    mysekaiFixtureBonusRate: string;
-    mysekaiFixtureOverrides: DeckMysekaiFixtureOverride[];
-    unitFilter: string;
-    attrFilter: string;
-    characterFilterIds: number[];
-    useCurrentDeck: boolean;
-    limit: string;
-    timeoutSeconds: string;
-}
 
-const DEFAULT_SAVED_CONFIG: SavedConfig = {
-    mode: "event",
-    eventId: "",
-    selectedEventType: null,
-    eventBonusCharacterIds: [],
-    liveType: "multi",
-    supportCharacterId: null,
-    challengeCharacterId: null,
-    musicId: "",
-    difficulty: "master",
-    cardConfig: DEFAULT_CARD_CONFIG,
-    target: "score",
-    bonusTargets: "",
-    simulateEnabled: false,
-    simType: "marathon",
-    simAttr: "",
-    simUnit: "",
-    simTurn: 3,
-    simCharacterId: null,
-    customSubMode: "unit",
-    customUnit: "light_sound",
-    customCharacterIds: [],
-    customCharacterUnits: {},
-    customAttr: "",
-    strongestTarget: "power",
-    multiTeammatePower: "",
-    multiTeammateScoreUp: "",
-    multiScoreUpLowerBound: "",
-    skillOrder: "average",
-    specificSkillOrder: "",
-    skillReference: "average",
-    keepAfterTrainingState: false,
-    bestSkillAsLeader: true,
-    minimize: false,
-    supportMasterMax: false,
-    supportSkillMax: false,
-    filterOtherUnit: false,
-    boost: "",
-    otherScore: "",
-    leaderCharacterId: null,
-    fixedCards: [],
-    fixedCharacters: [],
-    excludedCards: [],
-    singleCardOverrides: [],
-    areaItemLevel: "",
-    areaItemOverrides: [],
-    characterRank: "",
-    characterRankOverrides: [],
-    mysekaiGateLevel: "",
-    mysekaiGateOverrides: [],
-    mysekaiFixtureBonusRate: "",
-    mysekaiFixtureOverrides: [],
-    unitFilter: "",
-    attrFilter: "",
-    characterFilterIds: [],
-    useCurrentDeck: false,
-    limit: "10",
-    timeoutSeconds: "120",
-};
 
 function getErrorMessage(error: string, t: TranslationFn): string {
     switch (error) {
@@ -812,7 +683,8 @@ export default function DeckRecommendClient() {
     const {
         mode, eventId, selectedEventType, eventBonusCharacterIds, liveType, supportCharacterId,
         challengeCharacterId, musicId, difficulty, cardConfig, target, bonusTargets,
-        simulateEnabled, simType, simAttr, simUnit, simTurn, simCharacterId,
+        simulateEnabled, simType, simAttr, simUnit, simBonusMode, simCharacterIds,
+        simCharacterUnits, simTurn, simCharacterId,
         customSubMode, customUnit, customCharacterIds, customCharacterUnits, customAttr,
         strongestTarget, multiTeammatePower, multiTeammateScoreUp, multiScoreUpLowerBound,
         skillOrder, specificSkillOrder, skillReference, keepAfterTrainingState,
@@ -1226,6 +1098,17 @@ export default function DeckRecommendClient() {
             setError(t("page.deckRecommend.errors.simulateUnitRequired"));
             return;
         }
+        if (mode === "event" && simulateEnabled && simType === "world_bloom" && simTurn === 3 && !simCharacterId) {
+            setError(t("page.deckRecommend.errors.supportCharacterRequired"));
+            return;
+        }
+        if (
+            mode === "event" && simulateEnabled && simType !== "world_bloom"
+            && simBonusMode === "character" && simCharacterIds.length === 0
+        ) {
+            setError(t("page.deckRecommend.errors.customCharactersRequired"));
+            return;
+        }
 
         calculateScrollYRef.current = typeof window !== "undefined" ? window.scrollY : null;
         setError(null);
@@ -1241,66 +1124,11 @@ export default function DeckRecommendClient() {
             return;
         }
 
-        const effectiveFixedCards = [...fixedCards];
-
-        const workerArgs = {
+        const workerArgs = buildDeckWorkerArgs(state, {
             server,
-            userId: userId.trim(),
-            mode,
-            eventId: eventId ? parseInt(eventId) : undefined,
-            eventType: selectedEventType ?? undefined,
-            liveType,
-            supportCharacterId: (mode === "event" && selectedEventType === "world_bloom") ? (supportCharacterId ?? undefined) : undefined,
-            challengeCharacterId: challengeCharacterId ?? undefined,
-            musicId: musicId ? parseInt(musicId) : undefined,
-            difficulty: needsMusic ? difficulty : undefined,
-            cardConfig,
-            target: mode === "event" ? target : undefined,
-            bonusTargets: bonusTargetsParsed ?? undefined,
-            simulateEnabled,
-            simType,
-            simAttr: simAttr || undefined,
-            simUnit: simUnit || undefined,
-            simTurn: simType === "world_bloom" ? simTurn : undefined,
-            simCharacterId: simCharacterId ?? undefined,
-            customSubMode,
-            customUnit: customSubMode === "unit" ? customUnit : undefined,
-            customCharacterIds: customSubMode === "character" ? customCharacterIds : undefined,
-            customCharacterUnits: customSubMode === "character" ? customCharacterUnits : undefined,
-            customAttr: customAttr || undefined,
-            strongestTarget: mode === "strongest" ? strongestTarget : undefined,
-            multiTeammatePower: multiTeammatePower ? parseInt(multiTeammatePower) : undefined,
-            multiTeammateScoreUp: multiTeammateScoreUp ? parseInt(multiTeammateScoreUp) : undefined,
-            multiScoreUpLowerBound: multiScoreUpLowerBound ? parseInt(multiScoreUpLowerBound) : undefined,
-            skillOrder,
-            specificSkillOrder: skillOrder === "specific" ? specificSkillOrder : undefined,
-            skillReference,
-            keepAfterTrainingState,
-            bestSkillAsLeader,
-            minimize: mode === "weakest" ? true : minimize,
-            supportMasterMax,
-            supportSkillMax,
-            filterOtherUnit,
-            boost: boost ? parseInt(boost) : undefined,
-            otherScore: otherScore ? parseInt(otherScore) : undefined,
-            fixedCards: effectiveFixedCards.length > 0 ? effectiveFixedCards : undefined,
-            fixedCharacters: fixedCharacters.length > 0 ? fixedCharacters : undefined,
-            excludedCards: excludedCards.length > 0 ? excludedCards : undefined,
-            singleCardOverrides: singleCardOverrides.length > 0 ? singleCardOverrides : undefined,
-            areaItemLevel: areaItemLevel ? parseInt(areaItemLevel) : undefined,
-            areaItemOverrides: areaItemOverrides.length > 0 ? areaItemOverrides : undefined,
-            characterRank: characterRank ? parseInt(characterRank) : undefined,
-            characterRankOverrides: characterRankOverrides.length > 0 ? characterRankOverrides : undefined,
-            mysekaiGateLevel: mysekaiGateLevel ? parseInt(mysekaiGateLevel) : undefined,
-            mysekaiGateOverrides: mysekaiGateOverrides.length > 0 ? mysekaiGateOverrides : undefined,
-            mysekaiFixtureBonusRate: mysekaiFixtureBonusRate ? parseFloat(mysekaiFixtureBonusRate) : undefined,
-            mysekaiFixtureOverrides: mysekaiFixtureOverrides.length > 0 ? mysekaiFixtureOverrides : undefined,
-            unitFilter: unitFilter || undefined,
-            attrFilter: attrFilter || undefined,
-            characterFilterIds: characterFilterIds.length > 0 ? characterFilterIds : undefined,
-            limit: Math.min(30, Math.max(1, parseInt(limit) || 10)),
-            timeoutMs: Math.min(300, Math.max(5, parseInt(timeoutSeconds) || 120)) * 1000,
-        };
+            userId,
+            bonusTargets: bonusTargetsParsed,
+        });
 
         const worker = getOrCreateWorker();
         const oauthAccessToken = getOAuthAccessTokenForGameUser(server, userId.trim());
@@ -1542,6 +1370,105 @@ export default function DeckRecommendClient() {
                                         </div>
                                     ) : (
                                         <div>
+                                            {/* 团活按团给加成，混活直接指定加成角色集合。 */}
+                                            <SectionTitle text={t("page.deckRecommend.config.customTitle")} />
+                                            <div className="flex gap-2 mb-3">
+                                                <button type="button" onClick={() => patch({ simBonusMode: "unit" })} className={pill(simBonusMode === "unit")}>
+                                                    {t("page.deckRecommend.config.customSubMode.unit")}
+                                                </button>
+                                                <button type="button" onClick={() => patch({ simBonusMode: "character" })} className={pill(simBonusMode === "character")}>
+                                                    {t("page.deckRecommend.config.customSubMode.character")}
+                                                </button>
+                                            </div>
+                                            {simBonusMode === "unit" ? (
+                                                <div className="mb-3">
+                                                    <SectionTitle text={t("page.deckRecommend.config.simulateUnit")} />
+                                                    <div className="flex flex-wrap gap-2">
+                                                        {UNIT_BONUS_OPTIONS.map((unit) => {
+                                                            const isSelected = simUnit === unit.value;
+                                                            return (
+                                                                <button
+                                                                    key={unit.value}
+                                                                    type="button"
+                                                                    onClick={() => patch({ simUnit: isSelected ? "" : unit.value })}
+                                                                    className={`p-2 rounded-xl transition-all border ${
+                                                                        isSelected
+                                                                            ? "ring-2 ring-miku shadow-md bg-white border-transparent dark:bg-miku/15 dark:border-miku/40"
+                                                                            : "bg-white/70 dark:bg-slate-800 border-slate-200/80 dark:border-slate-700 hover:bg-slate-100"
+                                                                    }`}
+                                                                    title={t(unit.labelKey)}
+                                                                >
+                                                                    <div className="w-7 h-7 relative">
+                                                                        <Image src={`/data/icon/${unit.icon}`} alt={t(unit.labelKey)} fill className="object-contain" unoptimized />
+                                                                    </div>
+                                                                </button>
+                                                            );
+                                                        })}
+                                                    </div>
+                                                </div>
+                                            ) : (
+                                                <div className="mb-3">
+                                                    <SectionTitle text={t("page.deckRecommend.config.simulateCharacter")} />
+                                                    <p className="text-xs text-slate-400 mb-2">{t("page.deckRecommend.config.customCharactersHint")}</p>
+                                                    <CharacterMultiGrid
+                                                        selected={simCharacterIds}
+                                                        onToggle={(id) => {
+                                                            setState((prev) => {
+                                                                const next = prev.simCharacterIds.includes(id)
+                                                                    ? prev.simCharacterIds.filter((v) => v !== id)
+                                                                    : prev.simCharacterIds.length >= 5
+                                                                        ? prev.simCharacterIds
+                                                                        : [...prev.simCharacterIds, id].sort((a, b) => a - b);
+                                                                const units = { ...prev.simCharacterUnits };
+                                                                if (!next.includes(id)) delete units[id];
+                                                                return { ...prev, simCharacterIds: next, simCharacterUnits: units };
+                                                            });
+                                                        }}
+                                                        maxCount={5}
+                                                    />
+                                                    {simCharacterIds.some((id) => id >= VIRTUAL_SINGER_ID_MIN) && (
+                                                        <div className="mt-4 space-y-2">
+                                                            {simCharacterIds.filter((id) => id >= VIRTUAL_SINGER_ID_MIN).map((id) => (
+                                                                <div key={id} className="flex items-center gap-2 flex-wrap">
+                                                                    <img src={getCharacterIconUrl(id)} alt="" className="w-7 h-7 rounded-full object-contain" loading="lazy" />
+                                                                    <span className="text-xs text-slate-500 dark:text-slate-400 font-medium w-24 truncate">
+                                                                        {getCharacterName(t, id, "short")}
+                                                                    </span>
+                                                                    <div className="flex flex-wrap gap-1.5">
+                                                                        {UNIT_BONUS_OPTIONS.map((unit) => {
+                                                                            const isSelected = simCharacterUnits[id] === unit.value;
+                                                                            return (
+                                                                                <button
+                                                                                    key={unit.value}
+                                                                                    type="button"
+                                                                                    onClick={() =>
+                                                                                        setState((prev) => {
+                                                                                            const units = { ...prev.simCharacterUnits };
+                                                                                            if (units[id] === unit.value) delete units[id];
+                                                                                            else units[id] = unit.value;
+                                                                                            return { ...prev, simCharacterUnits: units };
+                                                                                        })
+                                                                                    }
+                                                                                    className={`p-1.5 rounded-lg transition-all border ${
+                                                                                        isSelected
+                                                                                            ? "ring-2 ring-miku shadow-xs bg-white border-transparent dark:bg-miku/20 dark:border-miku/40"
+                                                                                            : "bg-slate-100 dark:bg-slate-800 border-transparent hover:bg-slate-200"
+                                                                                    }`}
+                                                                                    title={t(unit.labelKey)}
+                                                                                >
+                                                                                    <div className="w-5 h-5 relative">
+                                                                                        <Image src={`/data/icon/${unit.icon}`} alt={t(unit.labelKey)} fill className="object-contain" unoptimized />
+                                                                                    </div>
+                                                                                </button>
+                                                                            );
+                                                                        })}
+                                                                    </div>
+                                                                </div>
+                                                            ))}
+                                                        </div>
+                                                    )}
+                                                </div>
+                                            )}
                                             <SectionTitle text={t("page.deckRecommend.config.simulateAttr")} />
                                             <div className="flex flex-wrap gap-2">
                                                 {ATTR_OPTIONS.map((attr) => {

--- a/web/src/lib/deck-engine/wasm-version.ts
+++ b/web/src/lib/deck-engine/wasm-version.ts
@@ -1,2 +1,2 @@
 // 由 scripts/copy-wasm-artifacts.mjs 生成，请勿手改。
-export const DECK_ENGINE_WASM_VERSION = "0.0.11";
+export const DECK_ENGINE_WASM_VERSION = "0.0.12";

--- a/web/src/lib/deck-recommend/engine-options.ts
+++ b/web/src/lib/deck-recommend/engine-options.ts
@@ -1,0 +1,217 @@
+/**
+ * 页面参数 → 引擎 options 的纯映射。
+ *
+ * 单独成模块是为了可测：这一层丢字段不会报错，只会静默退化成另一种搜索
+ * （模拟活动退回真实活动、指定队长被忽略），必须由测试直接盯住。
+ * 运行时零依赖（只有 import type），Node 可直接导入。
+ */
+import type { DeckWorkerInput } from "./engine-types";
+
+/** 活动主表里本映射需要的最小字段。 */
+export interface EngineOptionsEventRow {
+    id: number;
+    eventType?: string;
+}
+
+export interface EngineOptionsContext {
+    /** 活动主表：用于把混战活动的 multi 换算成 cheerful。 */
+    eventRows: readonly EngineOptionsEventRow[];
+    /** EventSelector 里 WL3 模拟分组占用的假活动 ID。 */
+    wl3SimulationEventIds: readonly number[];
+}
+
+const RARITY_CONFIG_KEYS: Record<string, string> = {
+    rarity_1: "rarity1Config",
+    rarity_2: "rarity2Config",
+    rarity_3: "rarity3Config",
+    rarity_4: "rarity4Config",
+    rarity_birthday: "rarityBirthdayConfig",
+};
+
+/** 特定技能顺序：UI 用 1-based 数字串（1=队长位），引擎消费 0-based。 */
+function toEngineSkillOrder(text: string): string | undefined {
+    const digits = text.replace(/\D/g, "").split("");
+    if (digits.length !== 5) return undefined;
+    return digits.map((d) => String(Number(d) - 1)).join(",");
+}
+
+/** 组装引擎 options；活动类型相关的 live_type 转换在此完成。 */
+export function buildEngineOptions(
+    input: DeckWorkerInput,
+    { eventRows, wl3SimulationEventIds }: EngineOptionsContext,
+): Record<string, unknown> {
+    const {
+        mode, eventId, eventType, simulatedEvent, liveType, supportCharacterId,
+        challengeCharacterId, musicId, difficulty, cardConfig, target, bonusTargets,
+        customUnit, customCharacterIds, customCharacterUnits, customAttr, strongestTarget,
+        multiTeammatePower, multiTeammateScoreUp, multiScoreUpLowerBound,
+        skillOrder, specificSkillOrder, skillReference, keepAfterTrainingState,
+        bestSkillAsLeader, minimize, boost, otherScore, unitFilter, attrFilter,
+        supportMasterMax, supportSkillMax, filterOtherUnit,
+        fixedCards, fixedCharacters, excludedCards, singleCardOverrides,
+        leaderCharacterId, limit, timeoutMs,
+    } = input;
+
+    let computedLiveType: string = liveType;
+    const usesRealEvent = Boolean(eventId) && !simulatedEvent;
+    if (usesRealEvent && (mode === "event" || mode === "mysekai")) {
+        const event0 = eventRows.find((it) => it.id === eventId);
+        if (event0?.eventType === "cheerful_carnival" && computedLiveType === "multi") {
+            computedLiveType = "cheerful";
+        }
+    }
+    // 模拟混战活动同样要走 cheerful 结算，否则分数按普通协力算。
+    if (mode === "event" && simulatedEvent?.eventType === "cheerful_carnival" && computedLiveType === "multi") {
+        computedLiveType = "cheerful";
+    }
+    if (mode === "challenge") {
+        computedLiveType = liveType === "auto" ? "challenge_auto" : "challenge";
+    }
+
+    const options: Record<string, unknown> = {
+        live_type: computedLiveType,
+        limit: limit ?? 10,
+        timeout_ms: timeoutMs ?? 120_000,
+    };
+    if (mode !== "weakest") {
+        options.music_id = musicId;
+        options.music_diff = difficulty;
+    }
+
+    if (mode === "weakest") {
+        // 最弱组卡：无活动、无乐曲、不应用任何养成覆盖，直接按账号真实数据求最低综合力。
+        options.target = "power";
+        options.minimize = true;
+        options.live_type = "solo";
+        return options;
+    }
+
+    for (const [rarityKey, configKey] of Object.entries(RARITY_CONFIG_KEYS)) {
+        const config = cardConfig[rarityKey];
+        if (!config) continue;
+        options[configKey] = {
+            disable: config.disable,
+            levelMax: config.levelMax,
+            episodeRead: config.episodeRead,
+            masterMax: config.masterMax,
+            skillMax: config.skillMax,
+        };
+    }
+
+    if (multiTeammatePower) options.multiLiveTeammatePower = multiTeammatePower;
+    if (multiTeammateScoreUp) options.multiLiveTeammateScoreUp = multiTeammateScoreUp;
+    if (multiScoreUpLowerBound) options.multiLiveScoreUpLowerBound = multiScoreUpLowerBound;
+    if (skillOrder) options.liveSkillOrder = skillOrder;
+    const engineOrder = specificSkillOrder ? toEngineSkillOrder(specificSkillOrder) : undefined;
+    if (skillOrder === "specific" && engineOrder) options.specificSkillOrder = engineOrder;
+    if (skillReference) options.skillReferenceChooseStrategy = skillReference;
+    if (keepAfterTrainingState) options.keepAfterTrainingState = true;
+    if (bestSkillAsLeader === false) options.bestSkillAsLeader = false;
+    if (minimize) options.minimize = true;
+    if (supportMasterMax) options.supportMasterMax = true;
+    if (supportSkillMax) options.supportSkillMax = true;
+    if (filterOtherUnit) options.filterOtherUnit = true;
+    if (boost !== undefined) options.boost = boost;
+    if (otherScore) options.otherScore = otherScore;
+    if (unitFilter) options.unitFilter = unitFilter;
+    if (attrFilter) options.attrFilter = attrFilter;
+    if (leaderCharacterId) options.forced_leader_character_id = leaderCharacterId;
+    if (fixedCards?.length) options.fixedCards = fixedCards;
+    if (fixedCharacters?.length) options.fixedCharacters = fixedCharacters;
+    if (excludedCards?.length) options.excludedCards = excludedCards;
+    if (singleCardOverrides?.length) {
+        options.singleCardConfigs = singleCardOverrides.map((entry) => ({
+            cardId: entry.cardId,
+            config: {
+                level: entry.level,
+                skillLevel: entry.skillLevel,
+                masterRank: entry.masterRank,
+                episodeReadCount: entry.episodeReadCount,
+                canvas: entry.canvas ?? false,
+            },
+        }));
+    }
+
+    if (mode === "event" && simulatedEvent) {
+        // 模拟活动：不带 event_id，由引擎按条件合成活动行。
+        options.event_type = simulatedEvent.eventType;
+        if (simulatedEvent.attr) options.event_attr = simulatedEvent.attr;
+        if (simulatedEvent.unit) options.event_unit = simulatedEvent.unit;
+        // 混活：直接给加成角色集合；引擎优先用它，不再按 event_unit 展开整团。
+        if (simulatedEvent.characterIds?.length) {
+            options.custom_bonus_character_ids = simulatedEvent.characterIds;
+            if (simulatedEvent.characterUnits && Object.keys(simulatedEvent.characterUnits).length > 0) {
+                options.custom_bonus_character_support_units = Object.fromEntries(
+                    Object.entries(simulatedEvent.characterUnits).map(([id, unit]) => [String(id), unit]),
+                );
+            }
+        }
+        if (simulatedEvent.worldBloomTurn) {
+            options.world_bloom_event_turn = simulatedEvent.worldBloomTurn;
+            if (simulatedEvent.worldBloomTurn === 3 && simulatedEvent.worldBloomCharacterId) {
+                options.world_bloom_character_id = simulatedEvent.worldBloomCharacterId;
+            }
+        }
+        const searchTarget = target ?? "score";
+        options.target = searchTarget;
+        if (searchTarget === "bonus" && bonusTargets?.length) {
+            options.target_bonus_list = bonusTargets;
+        }
+        return options;
+    }
+
+    if (mode === "event") {
+        // EventSelector 的 WL3 模拟活动（3200001..3200005）转成引擎模拟参数。
+        if (eventId !== undefined && wl3SimulationEventIds.includes(eventId)) {
+            if (!supportCharacterId) throw new Error("wl3 mode requires supportCharacterId");
+            options.world_bloom_event_turn = 3;
+            options.world_bloom_character_id = supportCharacterId;
+            options.target = target ?? "score";
+            if ((target ?? "score") === "bonus" && bonusTargets?.length) {
+                options.target_bonus_list = bonusTargets;
+            }
+            return options;
+        }
+        if (!eventId) throw new Error("event mode requires eventId");
+        options.event_id = eventId;
+        if (eventType === "world_bloom" && supportCharacterId) {
+            options.world_bloom_character_id = supportCharacterId;
+        }
+        const searchTarget = target ?? "score";
+        options.target = searchTarget;
+        if (searchTarget === "bonus" && bonusTargets?.length) {
+            options.target_bonus_list = bonusTargets;
+        }
+        return options;
+    }
+
+    if (mode === "challenge") {
+        if (!challengeCharacterId) throw new Error("challenge mode requires challengeCharacterId");
+        options.challenge_live_character_id = challengeCharacterId;
+        return options;
+    }
+
+    if (mode === "custom") {
+        if (customUnit) options.event_unit = customUnit;
+        if (customCharacterIds?.length) options.custom_bonus_character_ids = customCharacterIds;
+        if (customCharacterUnits && Object.keys(customCharacterUnits).length > 0) {
+            options.custom_bonus_character_support_units = Object.fromEntries(
+                Object.entries(customCharacterUnits).map(([id, unit]) => [String(id), unit]),
+            );
+        }
+        if (customAttr) options.custom_bonus_attr = customAttr;
+        return options;
+    }
+
+    if (mode === "strongest") {
+        options.target = strongestTarget ?? "power";
+        return options;
+    }
+
+
+    // mysekai
+    if (!eventId) throw new Error("mysekai mode requires eventId");
+    options.event_id = eventId;
+    options.target = "mysekai";
+    return options;
+}

--- a/web/src/lib/deck-recommend/engine-types.ts
+++ b/web/src/lib/deck-recommend/engine-types.ts
@@ -4,7 +4,9 @@
 
 export type DeckRecommendMode = "event" | "challenge" | "custom" | "strongest" | "weakest" | "mysekai";
 
-export type DeckLiveType = "multi" | "solo" | "auto" | "cheerful";
+/** 页面可选的 live 类型；challenge 由挑战模式发出，worker 再拆成
+ *  challenge / challenge_auto。 */
+export type DeckLiveType = "multi" | "solo" | "auto" | "cheerful" | "challenge";
 
 export type DeckTarget = "score" | "power" | "bonus";
 
@@ -85,8 +87,12 @@ export interface DeckSimulatedEvent {
     /** marathon / cheerful_carnival / world_bloom。 */
     eventType: string;
     attr?: string;
-    /** 活动加成团（连接世界 1/2 轮必需）。 */
+    /** 活动加成团（团活模拟；连接世界 1/2 轮必需）。 */
     unit?: string;
+    /** 混活模拟：直接指定加成角色集合，优先于 unit 展开的整团。 */
+    characterIds?: number[];
+    /** 混活模拟：VS 角色对应的支援团约束（characterId → unit）。 */
+    characterUnits?: Record<number, string>;
     /** 连接世界章节轮次（1/2/3；3 为 WL3 模拟终章）。 */
     worldBloomTurn?: number;
     /** 连接世界第 3 轮的章节角色。 */
@@ -109,8 +115,10 @@ export interface DeckWorkerInput {
     supportCharacterId?: number;
     /** 挑战组卡的目标角色。 */
     challengeCharacterId?: number;
-    musicId: number;
-    difficulty: string;
+    /** 乐曲 ID；烤森 / 最弱组卡不需要乐曲，可缺省。 */
+    musicId?: number;
+    /** 难度；同上，无乐曲时可缺省。 */
+    difficulty?: string;
     cardConfig: DeckCardConfig;
     /** 组卡目标（活动/烤森模式）。 */
     target?: DeckTarget;

--- a/web/src/lib/deck-recommend/engine-worker.ts
+++ b/web/src/lib/deck-recommend/engine-worker.ts
@@ -14,7 +14,11 @@ import {
     SnowyDataProvider,
     type HarukiServer,
 } from "@/lib/deck-recommend/data-provider";
-import { getWl3SimulationGroupByEventId } from "@/lib/world-bloom-simulation";
+import { WL3_SIMULATION_GROUPS } from "@/lib/world-bloom-simulation";
+import {
+    buildEngineOptions,
+    type EngineOptionsEventRow,
+} from "@/lib/deck-recommend/engine-options";
 import {
     loadDeckEngine,
     type DeckEngine,
@@ -29,19 +33,6 @@ import type {
     DeckWorkerInput,
     DeckWorkerOutput,
 } from "./engine-types";
-
-interface EventInfoLite {
-    id: number;
-    eventType?: string;
-}
-
-const RARITY_CONFIG_KEYS: Record<string, string> = {
-    rarity_1: "rarity1Config",
-    rarity_2: "rarity2Config",
-    rarity_3: "rarity3Config",
-    rarity_4: "rarity4Config",
-    rarity_birthday: "rarityBirthdayConfig",
-};
 
 function sendProgress(stage: string, percent: number, progressKey: string) {
     const message: DeckWorkerOutput = { type: "progress", stage, percent, progressKey };
@@ -278,7 +269,10 @@ async function runDeck(input: DeckWorkerInput): Promise<DeckWorkerOutput> {
     try {
         sendProgress("calculating", 50, "page.deckRecommend.progress.calculating");
 
-        const options = await buildOptions(input, (tables.events ?? []) as EventInfoLite[]);
+        const options = buildEngineOptions(input, {
+            eventRows: (tables.events ?? []) as EngineOptionsEventRow[],
+            wl3SimulationEventIds: WL3_SIMULATION_GROUPS.map((group) => group.eventId),
+        });
         const { decks, performance } = engine.recommend(options, user);
 
         const result = decks.map(
@@ -335,182 +329,6 @@ async function runDeck(input: DeckWorkerInput): Promise<DeckWorkerOutput> {
             engine.disposeUser(user);
         }
     }
-}
-
-/** 特定技能顺序：UI 用 1-based 数字串（1=队长位），引擎消费 0-based。 */
-function toEngineSkillOrder(text: string): string | undefined {
-    const digits = text.replace(/\D/g, "").split("");
-    if (digits.length !== 5) return undefined;
-    return digits.map((d) => String(Number(d) - 1)).join(",");
-}
-
-/** 组装引擎 options；活动类型相关的 live_type 转换在此完成。 */
-async function buildOptions(
-    input: DeckWorkerInput,
-    eventRows: EventInfoLite[],
-): Promise<Record<string, unknown>> {
-    const {
-        mode, eventId, eventType, simulatedEvent, liveType, supportCharacterId,
-        challengeCharacterId, musicId, difficulty, cardConfig, target, bonusTargets,
-        customUnit, customCharacterIds, customCharacterUnits, customAttr, strongestTarget,
-        multiTeammatePower, multiTeammateScoreUp, multiScoreUpLowerBound,
-        skillOrder, specificSkillOrder, skillReference, keepAfterTrainingState,
-        bestSkillAsLeader, minimize, boost, otherScore, unitFilter, attrFilter,
-        supportMasterMax, supportSkillMax, filterOtherUnit,
-        fixedCards, fixedCharacters, excludedCards, singleCardOverrides,
-        leaderCharacterId, limit, timeoutMs,
-    } = input;
-
-    let computedLiveType: string = liveType;
-    const usesRealEvent = Boolean(eventId) && !simulatedEvent;
-    if (usesRealEvent && (mode === "event" || mode === "mysekai")) {
-        const event0 = eventRows.find((it) => it.id === eventId);
-        if (event0?.eventType === "cheerful_carnival" && computedLiveType === "multi") {
-            computedLiveType = "cheerful";
-        }
-    }
-    if (mode === "challenge") {
-        computedLiveType = liveType === "auto" ? "challenge_auto" : "challenge";
-    }
-
-    const options: Record<string, unknown> = {
-        live_type: computedLiveType,
-        limit: limit ?? 10,
-        timeout_ms: timeoutMs ?? 120_000,
-    };
-    if (mode !== "weakest") {
-        options.music_id = musicId;
-        options.music_diff = difficulty;
-    }
-
-    if (mode === "weakest") {
-        // 最弱组卡：无活动、无乐曲、不应用任何养成覆盖，直接按账号真实数据求最低综合力。
-        options.target = "power";
-        options.minimize = true;
-        options.live_type = "solo";
-        return options;
-    }
-
-    for (const [rarityKey, configKey] of Object.entries(RARITY_CONFIG_KEYS)) {
-        const config = cardConfig[rarityKey];
-        if (!config) continue;
-        options[configKey] = {
-            disable: config.disable,
-            levelMax: config.levelMax,
-            episodeRead: config.episodeRead,
-            masterMax: config.masterMax,
-            skillMax: config.skillMax,
-        };
-    }
-
-    if (multiTeammatePower) options.multiLiveTeammatePower = multiTeammatePower;
-    if (multiTeammateScoreUp) options.multiLiveTeammateScoreUp = multiTeammateScoreUp;
-    if (multiScoreUpLowerBound) options.multiLiveScoreUpLowerBound = multiScoreUpLowerBound;
-    if (skillOrder) options.liveSkillOrder = skillOrder;
-    const engineOrder = specificSkillOrder ? toEngineSkillOrder(specificSkillOrder) : undefined;
-    if (skillOrder === "specific" && engineOrder) options.specificSkillOrder = engineOrder;
-    if (skillReference) options.skillReferenceChooseStrategy = skillReference;
-    if (keepAfterTrainingState) options.keepAfterTrainingState = true;
-    if (bestSkillAsLeader === false) options.bestSkillAsLeader = false;
-    if (minimize) options.minimize = true;
-    if (supportMasterMax) options.supportMasterMax = true;
-    if (supportSkillMax) options.supportSkillMax = true;
-    if (filterOtherUnit) options.filterOtherUnit = true;
-    if (boost !== undefined) options.boost = boost;
-    if (otherScore) options.otherScore = otherScore;
-    if (unitFilter) options.unitFilter = unitFilter;
-    if (attrFilter) options.attrFilter = attrFilter;
-    if (leaderCharacterId) options.forced_leader_character_id = leaderCharacterId;
-    if (fixedCards?.length) options.fixedCards = fixedCards;
-    if (fixedCharacters?.length) options.fixedCharacters = fixedCharacters;
-    if (excludedCards?.length) options.excludedCards = excludedCards;
-    if (singleCardOverrides?.length) {
-        options.singleCardConfigs = singleCardOverrides.map((entry) => ({
-            cardId: entry.cardId,
-            config: {
-                level: entry.level,
-                skillLevel: entry.skillLevel,
-                masterRank: entry.masterRank,
-                episodeReadCount: entry.episodeReadCount,
-                canvas: entry.canvas ?? false,
-            },
-        }));
-    }
-
-    if (mode === "event" && simulatedEvent) {
-        // 模拟活动：覆盖真实活动，按条件合成活动行。
-        options.event_type = simulatedEvent.eventType;
-        if (simulatedEvent.attr) options.event_attr = simulatedEvent.attr;
-        if (simulatedEvent.unit) options.event_unit = simulatedEvent.unit;
-        if (simulatedEvent.worldBloomTurn) {
-            options.world_bloom_event_turn = simulatedEvent.worldBloomTurn;
-            if (simulatedEvent.worldBloomTurn === 3 && simulatedEvent.worldBloomCharacterId) {
-                options.world_bloom_character_id = simulatedEvent.worldBloomCharacterId;
-            }
-        }
-        const searchTarget = target ?? "score";
-        options.target = searchTarget;
-        if (searchTarget === "bonus" && bonusTargets?.length) {
-            options.target_bonus_list = bonusTargets;
-        }
-        return options;
-    }
-
-    if (mode === "event") {
-        // EventSelector 的 WL3 模拟活动（3200001..3200005）转成引擎模拟参数。
-        const wl3Group = getWl3SimulationGroupByEventId(String(eventId ?? ""));
-        if (wl3Group) {
-            if (!supportCharacterId) throw new Error("wl3 mode requires supportCharacterId");
-            options.world_bloom_event_turn = 3;
-            options.world_bloom_character_id = supportCharacterId;
-            options.target = target ?? "score";
-            if ((target ?? "score") === "bonus" && bonusTargets?.length) {
-                options.target_bonus_list = bonusTargets;
-            }
-            return options;
-        }
-        if (!eventId) throw new Error("event mode requires eventId");
-        options.event_id = eventId;
-        if (eventType === "world_bloom" && supportCharacterId) {
-            options.world_bloom_character_id = supportCharacterId;
-        }
-        const searchTarget = target ?? "score";
-        options.target = searchTarget;
-        if (searchTarget === "bonus" && bonusTargets?.length) {
-            options.target_bonus_list = bonusTargets;
-        }
-        return options;
-    }
-
-    if (mode === "challenge") {
-        if (!challengeCharacterId) throw new Error("challenge mode requires challengeCharacterId");
-        options.challenge_live_character_id = challengeCharacterId;
-        return options;
-    }
-
-    if (mode === "custom") {
-        if (customUnit) options.event_unit = customUnit;
-        if (customCharacterIds?.length) options.custom_bonus_character_ids = customCharacterIds;
-        if (customCharacterUnits && Object.keys(customCharacterUnits).length > 0) {
-            options.custom_bonus_character_support_units = Object.fromEntries(
-                Object.entries(customCharacterUnits).map(([id, unit]) => [String(id), unit]),
-            );
-        }
-        if (customAttr) options.custom_bonus_attr = customAttr;
-        return options;
-    }
-
-    if (mode === "strongest") {
-        options.target = strongestTarget ?? "power";
-        return options;
-    }
-
-
-    // mysekai
-    if (!eventId) throw new Error("mysekai mode requires eventId");
-    options.event_id = eventId;
-    options.target = "mysekai";
-    return options;
 }
 
 interface WarmupMessage {

--- a/web/src/lib/deck-recommend/worker-args.ts
+++ b/web/src/lib/deck-recommend/worker-args.ts
@@ -1,0 +1,272 @@
+/**
+ * 页面表单状态 → worker 入参的纯映射。
+ *
+ * 单独成模块是为了可测：worker 只认 `simulatedEvent` / `userDataOverrides` /
+ * `leaderCharacterId` 这些成组字段，散着发过去不会报错，只会静默失效
+ * （模拟活动退回真实活动并报缺 ID、指定队长与进阶覆盖被丢掉）。
+ * 运行时零依赖（只有 import type），Node 可直接导入做断言。
+ */
+import type {
+    DeckAreaItemOverride,
+    DeckCharacterRankOverride,
+    DeckLiveType,
+    DeckMysekaiFixtureOverride,
+    DeckMysekaiGateOverride,
+    DeckRecommendMode,
+    DeckSingleCardOverride,
+    DeckSkillOrder,
+    DeckSkillReference,
+    DeckTarget,
+    DeckTrainingConfig,
+    DeckWorkerInput,
+} from "./engine-types";
+
+/** 自定义加成 / 模拟活动加成的两种口径：整团 或 指定角色集合。 */
+export type CustomSubMode = "unit" | "character";
+
+/** 保存到 localStorage 的可序列化表单状态。 */
+export interface DeckFormState {
+    mode: DeckRecommendMode;
+    eventId: string;
+    selectedEventType: string | null;
+    eventBonusCharacterIds: number[];
+    liveType: DeckLiveType;
+    supportCharacterId: number | null;
+    challengeCharacterId: number | null;
+    musicId: string;
+    difficulty: string;
+    cardConfig: Record<string, DeckTrainingConfig>;
+    target: DeckTarget;
+    bonusTargets: string;
+    simulateEnabled: boolean;
+    simType: string;
+    simAttr: string;
+    simUnit: string;
+    simBonusMode: CustomSubMode;
+    simCharacterIds: number[];
+    simCharacterUnits: Record<number, string>;
+    simTurn: number;
+    simCharacterId: number | null;
+    customSubMode: CustomSubMode;
+    customUnit: string;
+    customCharacterIds: number[];
+    customCharacterUnits: Record<number, string>;
+    customAttr: string;
+    strongestTarget: "power" | "skill";
+    multiTeammatePower: string;
+    multiTeammateScoreUp: string;
+    multiScoreUpLowerBound: string;
+    skillOrder: DeckSkillOrder;
+    specificSkillOrder: string;
+    skillReference: DeckSkillReference;
+    keepAfterTrainingState: boolean;
+    bestSkillAsLeader: boolean;
+    minimize: boolean;
+    supportMasterMax: boolean;
+    supportSkillMax: boolean;
+    filterOtherUnit: boolean;
+    boost: string;
+    otherScore: string;
+    leaderCharacterId: number | null;
+    fixedCards: number[];
+    fixedCharacters: number[];
+    excludedCards: number[];
+    singleCardOverrides: DeckSingleCardOverride[];
+    areaItemLevel: string;
+    areaItemOverrides: DeckAreaItemOverride[];
+    characterRank: string;
+    characterRankOverrides: DeckCharacterRankOverride[];
+    mysekaiGateLevel: string;
+    mysekaiGateOverrides: DeckMysekaiGateOverride[];
+    mysekaiFixtureBonusRate: string;
+    mysekaiFixtureOverrides: DeckMysekaiFixtureOverride[];
+    unitFilter: string;
+    attrFilter: string;
+    characterFilterIds: number[];
+    useCurrentDeck: boolean;
+    limit: string;
+    timeoutSeconds: string;
+}
+
+/** 各稀有度的默认养成假设（满级 + 已读前后篇）。 */
+export const DEFAULT_CARD_CONFIG: Record<string, DeckTrainingConfig> = {
+    rarity_1: { disable: false, levelMax: true, episodeRead: true, masterMax: false, skillMax: false },
+    rarity_2: { disable: false, levelMax: true, episodeRead: true, masterMax: false, skillMax: false },
+    rarity_3: { disable: false, levelMax: true, episodeRead: true, masterMax: false, skillMax: false },
+    rarity_4: { disable: false, levelMax: true, episodeRead: true, masterMax: false, skillMax: false },
+    rarity_birthday: { disable: false, levelMax: true, episodeRead: true, masterMax: false, skillMax: false },
+};
+
+/** 表单初始值；测试与页面共用同一份，避免两边漂移。 */
+export const DEFAULT_DECK_FORM_STATE: DeckFormState = {
+    mode: "event",
+    eventId: "",
+    selectedEventType: null,
+    eventBonusCharacterIds: [],
+    liveType: "multi",
+    supportCharacterId: null,
+    challengeCharacterId: null,
+    musicId: "",
+    difficulty: "master",
+    cardConfig: DEFAULT_CARD_CONFIG,
+    target: "score",
+    bonusTargets: "",
+    simulateEnabled: false,
+    simType: "marathon",
+    simAttr: "",
+    simUnit: "",
+    simBonusMode: "unit",
+    simCharacterIds: [],
+    simCharacterUnits: {},
+    simTurn: 3,
+    simCharacterId: null,
+    customSubMode: "unit",
+    customUnit: "light_sound",
+    customCharacterIds: [],
+    customCharacterUnits: {},
+    customAttr: "",
+    strongestTarget: "power",
+    multiTeammatePower: "",
+    multiTeammateScoreUp: "",
+    multiScoreUpLowerBound: "",
+    skillOrder: "average",
+    specificSkillOrder: "",
+    skillReference: "average",
+    keepAfterTrainingState: false,
+    bestSkillAsLeader: true,
+    minimize: false,
+    supportMasterMax: false,
+    supportSkillMax: false,
+    filterOtherUnit: false,
+    boost: "",
+    otherScore: "",
+    leaderCharacterId: null,
+    fixedCards: [],
+    fixedCharacters: [],
+    excludedCards: [],
+    singleCardOverrides: [],
+    areaItemLevel: "",
+    areaItemOverrides: [],
+    characterRank: "",
+    characterRankOverrides: [],
+    mysekaiGateLevel: "",
+    mysekaiGateOverrides: [],
+    mysekaiFixtureBonusRate: "",
+    mysekaiFixtureOverrides: [],
+    unitFilter: "",
+    attrFilter: "",
+    characterFilterIds: [],
+    useCurrentDeck: false,
+    limit: "10",
+    timeoutSeconds: "120",
+};
+
+
+export interface DeckWorkerArgsContext {
+    server: string;
+    /** 未 trim 的原始输入。 */
+    userId: string;
+    /** 已解析的目标加成档位；未启用或解析失败为 null。 */
+    bonusTargets: number[] | null;
+}
+
+/** 把表单状态打包成 worker 入参。纯函数，无副作用。 */
+export function buildDeckWorkerArgs(
+    state: DeckFormState,
+    { server, userId, bonusTargets }: DeckWorkerArgsContext,
+): DeckWorkerInput {
+    const {
+        mode, eventId, selectedEventType, liveType, supportCharacterId,
+        challengeCharacterId, musicId, difficulty, cardConfig, target,
+        simulateEnabled, simType, simAttr, simUnit, simBonusMode, simCharacterIds,
+        simCharacterUnits, simTurn, simCharacterId,
+        customSubMode, customUnit, customCharacterIds, customCharacterUnits, customAttr,
+        strongestTarget, multiTeammatePower, multiTeammateScoreUp, multiScoreUpLowerBound,
+        skillOrder, specificSkillOrder, skillReference, keepAfterTrainingState,
+        bestSkillAsLeader, minimize, supportMasterMax, supportSkillMax, filterOtherUnit,
+        boost, otherScore, leaderCharacterId, fixedCards, fixedCharacters,
+        excludedCards, singleCardOverrides, limit, timeoutSeconds,
+        areaItemLevel, areaItemOverrides, characterRank, characterRankOverrides,
+        mysekaiGateLevel, mysekaiGateOverrides, mysekaiFixtureBonusRate, mysekaiFixtureOverrides,
+        unitFilter, attrFilter, characterFilterIds,
+    } = state;
+    const needsMusic = mode !== "mysekai" && mode !== "weakest";
+
+    return {
+            server,
+            userId: userId.trim(),
+            mode,
+            eventId: eventId ? parseInt(eventId) : undefined,
+            eventType: selectedEventType ?? undefined,
+            liveType,
+            supportCharacterId: (mode === "event" && selectedEventType === "world_bloom") ? (supportCharacterId ?? undefined) : undefined,
+            challengeCharacterId: challengeCharacterId ?? undefined,
+            musicId: musicId ? parseInt(musicId) : undefined,
+            difficulty: needsMusic ? difficulty : undefined,
+            cardConfig,
+            target: mode === "event" ? target : undefined,
+            bonusTargets: bonusTargets ?? undefined,
+            // 模拟活动：整个条件打包给 worker；缺了它 worker 会退回真实活动分支并因缺 eventId 报错。
+            simulatedEvent: mode === "event" && simulateEnabled
+                ? {
+                      eventType: simType,
+                      attr: simType !== "world_bloom" && simAttr ? simAttr : undefined,
+                      unit: simType === "world_bloom"
+                          ? (simTurn !== 3 ? simUnit || undefined : undefined)
+                          : (simBonusMode === "unit" ? simUnit || undefined : undefined),
+                      characterIds: simType !== "world_bloom" && simBonusMode === "character" && simCharacterIds.length > 0
+                          ? simCharacterIds
+                          : undefined,
+                      characterUnits: simType !== "world_bloom" && simBonusMode === "character"
+                          && Object.keys(simCharacterUnits).length > 0
+                          ? simCharacterUnits
+                          : undefined,
+                      worldBloomTurn: simType === "world_bloom" ? simTurn : undefined,
+                      worldBloomCharacterId:
+                          simType === "world_bloom" && simTurn === 3 ? simCharacterId ?? undefined : undefined,
+                  }
+                : undefined,
+            customUnit: customSubMode === "unit" ? customUnit : undefined,
+            customCharacterIds: customSubMode === "character" ? customCharacterIds : undefined,
+            customCharacterUnits: customSubMode === "character" ? customCharacterUnits : undefined,
+            customAttr: customAttr || undefined,
+            strongestTarget: mode === "strongest" ? strongestTarget : undefined,
+            multiTeammatePower: multiTeammatePower ? parseInt(multiTeammatePower) : undefined,
+            multiTeammateScoreUp: multiTeammateScoreUp ? parseInt(multiTeammateScoreUp) : undefined,
+            multiScoreUpLowerBound: multiScoreUpLowerBound ? parseInt(multiScoreUpLowerBound) : undefined,
+            skillOrder,
+            specificSkillOrder: skillOrder === "specific" ? specificSkillOrder : undefined,
+            skillReference,
+            keepAfterTrainingState,
+            bestSkillAsLeader,
+            minimize: mode === "weakest" ? true : minimize,
+            supportMasterMax,
+            supportSkillMax,
+            filterOtherUnit,
+            boost: boost ? parseInt(boost) : undefined,
+            otherScore: otherScore ? parseInt(otherScore) : undefined,
+            fixedCards: fixedCards.length > 0 ? [...fixedCards] : undefined,
+            fixedCharacters: fixedCharacters.length > 0 ? fixedCharacters : undefined,
+            excludedCards: excludedCards.length > 0 ? excludedCards : undefined,
+            singleCardOverrides: singleCardOverrides.length > 0 ? singleCardOverrides : undefined,
+            // 指定队长角色（引擎 forced_leader_character_id）。
+            leaderCharacterId: leaderCharacterId ?? undefined,
+            // 进阶数据覆盖：worker 只读 userDataOverrides 这一个对象；
+            // 最弱组卡按账号真实数据算，不带覆盖。
+            userDataOverrides: mode === "weakest" ? undefined : {
+                areaItemLevel: areaItemLevel ? parseInt(areaItemLevel) : null,
+                areaItemLevelOverrides: areaItemOverrides.length > 0 ? areaItemOverrides : undefined,
+                characterRank: characterRank ? parseInt(characterRank) : null,
+                characterRankOverrides: characterRankOverrides.length > 0 ? characterRankOverrides : undefined,
+                mysekaiGateLevel: mysekaiGateLevel ? parseInt(mysekaiGateLevel) : null,
+                mysekaiGateLevelOverrides: mysekaiGateOverrides.length > 0 ? mysekaiGateOverrides : undefined,
+                mysekaiFixtureBonusRate: mysekaiFixtureBonusRate ? parseFloat(mysekaiFixtureBonusRate) : null,
+                mysekaiFixtureBonusRateOverrides: mysekaiFixtureOverrides.length > 0 ? mysekaiFixtureOverrides : undefined,
+            },
+            unitFilter: unitFilter || undefined,
+            attrFilter: attrFilter || undefined,
+            characterFilterIds: characterFilterIds.length > 0 ? characterFilterIds : undefined,
+            limit: Math.min(30, Math.max(1, parseInt(limit) || 10)),
+            timeoutMs: Math.min(300, Math.max(5, parseInt(timeoutSeconds) || 120)) * 1000,
+    };
+}


### PR DESCRIPTION
## 问题

组卡页有三组参数实际上没有下发到引擎。worker 只读 `simulatedEvent` /
`userDataOverrides` / `leaderCharacterId` 三个成组字段，页面却把它们拆成了
散字段逐个发出去。散字段不会报错，只会静默失效：

- **模拟活动**开关完全无效，落回真实活动分支；没选活动时抛
  `event mode requires eventId`，页面直接把这句原文显示出来。
- **指定队长**被丢弃。固定一张卡时该卡永远排在第一个槽位，于是队长位归它，
  指定的角色不起作用。
- **进阶数据覆盖**（区域道具 / 角色等级 / 烤森门 / 玩偶加成）被丢弃，
  另有 `mysekaiGateLevelOverrides`、`mysekaiFixtureBonusRateOverrides`
  两个键名写错。

模拟面板此前只对连接世界提供加成团选择，马拉松与 5v5 只能选属性，
因此团活与混活无法描述。

引擎侧另有一处：`forced_leader_character_id` 只在连接世界终章写进搜索
上下文，其余活动一律丢弃，即使参数发对了也无效。该问题在
`@empty-sekai/allium-deck-wasm` 0.0.12 修复。

## 改动

- 恢复三组字段的打包，修正两个键名。
- 模拟活动支持按团或按加成角色集合两种口径，VS 角色可另外指定支援团；
  连接世界第 3 轮补上「未选章节角色」的前置校验。
- 把表单 → worker 入参 → 引擎 options 两层映射抽成运行时零依赖的纯函数
  （`worker-args.ts` / `engine-options.ts`），表单默认值挪过去与测试共用
  一份。这一层此前只有源码字符串检查，坏掉时照样是绿的。
- 组卡引擎 wasm 升到 0.0.12。`package-lock` 里 web 工作区的 resolved 此前
  停在 0.0.10、与 `package.json` 声明不一致，一并对齐；`bun.lock` 同步。
- `copy-wasm-artifacts.mjs` 支持 `ALLIUM_DECK_WASM_DIR`，联调未发版引擎时
  本地 wasm-pack 产物不会每次被 npm 包冲掉。

## 验证

- 新增 `npm run test:deck-payload`（33 项，不联网不进构建）：逐字段断言
  两层映射的落点，覆盖真实活动、模拟活动（团活 / 混活 / 5v5 / 连接世界
  1·2·3 轮）、指定队长、进阶覆盖，以及「模拟开启时一定不下发 event_id」
  这类回归护栏。做过变异检查：把映射改回散字段 → 11 项失败；删掉
  `leaderCharacterId` → 3 项失败；键名写回旧错名 → 1 项失败。
- `npm run test:deck-params`（真实账号 + 线上 masterdata，53 项全绿）补上
  指定队长（含与固定卡共存）、模拟团活 / 混活 / 5v5 / 连接世界第 1 轮
  五组真实搜索用例。同一套用发布前的 0.0.11 引擎跑，两项指定队长用例
  失败并复现原症状。
- `npm ci` 在干净目录复现 0.0.12；`bun install --frozen-lockfile` 通过。
- `tsc` / `eslint`（0 error）/ `lint:i18n` / `lint:i18n-usage` /
  `build:next` 全绿。
