### PR TITLE
test(deck): 加成档位用例改为动态取基线档位并对空结果容错

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
       "name": "moesekai",
       "version": "0.1.0",
       "dependencies": {
-        "@empty-sekai/allium-deck-wasm": "0.0.12",
+        "@empty-sekai/allium-deck-wasm": "0.0.13",
         "@supabase/supabase-js": "2.106.0",
         "@swc/helpers": "^0.5.15",
         "@types/qrcode": "^1.5.6",
@@ -176,7 +176,7 @@
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "https://registry.npmmirror.com/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
-    "@empty-sekai/allium-deck-wasm": ["@empty-sekai/allium-deck-wasm@0.0.12", "https://registry.npmmirror.com/@empty-sekai/allium-deck-wasm/-/allium-deck-wasm-0.0.12.tgz", {}, "sha512-r/AwWYIacv3paonZoDoUwWyNpelMLmtHwJXvtvh7VeNLnhFFHvgwKpDCP4oO/VbTC8ajPgpRjF/SumGD5WdzIA=="],
+    "@empty-sekai/allium-deck-wasm": ["@empty-sekai/allium-deck-wasm@0.0.13", "https://registry.npmjs.org/@empty-sekai/allium-deck-wasm/-/allium-deck-wasm-0.0.13.tgz", {}, "sha512-ZtVi8glNONhylkJtlCyzLtWCJgEqu2ytHVF4E0yZI90R/i7buQEI23A0ypOIi6cOp+CPg2mnOpimoY3Ejqglnw=="],
 
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "https://registry.npmmirror.com/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -264,7 +264,7 @@ func (s *Server) getServerCard(r *http.Request) map[string]interface{} {
 			"version": "1.0.0",
 		},
 		"description": "MCP server for pjsk.moe (Project SEKAI: Colorful Stage! viewer and database). Provides card lookup, music query, event schedules, character profiles, difficulty charts, and gacha data.",
-		"url": origin,
+		"url":         origin,
 		"transport": map[string]interface{}{
 			"type": "http",
 			"url":  origin + "/api/mcp",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12190,7 +12190,7 @@
             "name": "moesekai",
             "version": "0.1.0",
             "dependencies": {
-                "@empty-sekai/allium-deck-wasm": "0.0.12",
+                "@empty-sekai/allium-deck-wasm": "0.0.13",
                 "@supabase/supabase-js": "2.106.0",
                 "@swc/helpers": "^0.5.15",
                 "@types/qrcode": "^1.5.6",

--- a/web/package.json
+++ b/web/package.json
@@ -18,7 +18,7 @@
     "test:ssr-localized-links": "npm run build:next && node scripts/check-localized-link-ssr.mjs"
   },
   "dependencies": {
-    "@empty-sekai/allium-deck-wasm": "0.0.12",
+    "@empty-sekai/allium-deck-wasm": "0.0.13",
     "@supabase/supabase-js": "2.106.0",
     "@swc/helpers": "^0.5.15",
     "@types/qrcode": "^1.5.6",

--- a/web/scripts/test-deck-engine-params.mjs
+++ b/web/scripts/test-deck-engine-params.mjs
@@ -142,12 +142,12 @@ function buildMatrix(mod, decks, ctx) {
         },
         {
             name: 'targetBonusList exact hit',
-            base: BASE_EVENT, patch: { target: 'bonus', target_bonus_list: [420] },
+            base: BASE_EVENT, patch: { target: 'bonus', target_bonus_list: [ctx.bonusTier] },
             assert: (r, detail) => {
                 const bonus = r.decks[0]?.event_bonus_total ?? -1;
                 detail.value = bonus;
-                // 精确档位：只返回 total_bonus === 420 的卡组（不可达档为空数组）。
-                return r.decks.length > 0 && bonus === 420;
+                // 精确档位：只返回 total_bonus === 档位 的卡组（不可达档为空数组）。
+                return r.decks.length > 0 && bonus === ctx.bonusTier;
             },
             expect: '精确命中目标加成档位（wasm search_targets 路径）',
         },
@@ -355,7 +355,10 @@ async function main() {
     });
     const baseWlBonus = baseWlRun.decks[0]?.event_bonus_total ?? 0;
     console.log(`   基线：pool=${basePoolSize}, topPT=${baseEvent.decks[0]?.event_point}, wlBonus=${baseWlBonus}`);
-    const bonusRun = run({ ...BASE_EVENT, target: 'bonus', target_bonus_list: [420] });
+    // 档位取基线最优卡组的实际加成：该档位由盒内卡组构成，必然可达，
+    // 免受排行榜账号卡盒变化影响。
+    const bonusTier = Math.round(baseEvent.decks[0].cards.reduce((sum, c) => sum + (c.event_bonus ?? 0), 0));
+    const bonusRun = run({ ...BASE_EVENT, target: 'bonus', target_bonus_list: [bonusTier] });
     const challengeRun = run({
         region: 'jp', live_type: 'challenge', challenge_live_character_id: 1,
         music_id: 74, music_diff: 'master', target: 'score', limit: 1, timeout_ms: 60_000,
@@ -371,7 +374,7 @@ async function main() {
     const myRun = run({ region: 'jp', live_type: 'multi', music_id: 74, music_diff: 'master', target: 'mysekai', event_id: 215, limit: 1, timeout_ms: 60_000, ...ALL_RARITY_DEFAULTS });
 
     console.log('3) 参数矩阵逐项验证…');
-    const matrix = buildMatrix(mod, baseEvent.decks, { basePoolSize, baseWlBonus });
+    const matrix = buildMatrix(mod, baseEvent.decks, { basePoolSize, baseWlBonus, bonusTier });
     let pass = 0;
     const failures = [];
     for (const item of matrix) {
@@ -403,7 +406,7 @@ console.log('3C) 展示解码逐模式校验…');
     const decodeCases = [
         { name: 'event score', input: { mode: 'event', target: 'score', targetValue: baseEvent.decks[0].target_value, eventPoint: baseEvent.decks[0].event_point }, expect: (v) => v >= 100 && v <= 20000 },
         { name: 'event power', input: { mode: 'event', target: 'power', targetValue: run({ ...BASE_EVENT, target: 'power' }).decks[0].target_value }, expect: (v) => v >= 50000 && v <= 2000000 },
-        { name: 'event bonus', input: { mode: 'event', target: 'bonus', targetValue: bonusRun.decks[0].target_value }, expect: (v) => v >= 400 && v <= 430 },
+        { name: 'event bonus', input: { mode: 'event', target: 'bonus', targetValue: bonusRun.decks[0]?.target_value ?? -1 }, expect: (v) => v >= bonusTier - 5 && v <= bonusTier + 5 },
         { name: 'challenge score', input: { mode: 'challenge', targetValue: challengeRun.decks[0].target_value }, expect: (v) => v >= 1000000 && v <= 5000000 },
         { name: 'custom pt', input: { mode: 'custom', targetValue: customRun.decks[0].target_value, eventPoint: customRun.decks[0].event_point }, expect: (v) => v >= 100 && v <= 20000 },
         { name: 'strongest skill', input: { mode: 'strongest', strongestTarget: 'skill', targetValue: skillRun.decks[0].target_value }, expect: (v) => v >= 50 && v <= 400 },

--- a/web/src/lib/deck-engine/wasm-version.ts
+++ b/web/src/lib/deck-engine/wasm-version.ts
@@ -1,2 +1,2 @@
 // 由 scripts/copy-wasm-artifacts.mjs 生成，请勿手改。
-export const DECK_ENGINE_WASM_VERSION = "0.0.12";
+export const DECK_ENGINE_WASM_VERSION = "0.0.13";

--- a/web/tests/characterization/sitemap.characterization.test.mjs
+++ b/web/tests/characterization/sitemap.characterization.test.mjs
@@ -662,6 +662,7 @@ async function importSitemap() {
     },
     path: { join: (...parts) => parts.join("/") },
     getCanonicalOrigin: () => SITEMAP_TEST_ORIGIN,
+    getServerDataDir: () => "/moesekai-data",
     INDEXABLE_SEO_ROUTES: [],
     DEFAULT_ROUTE_LOCALE: localeRouting.DEFAULT_ROUTE_LOCALE,
     SUPPORTED_ROUTE_LOCALES: routeLocales,
@@ -673,6 +674,7 @@ async function importSitemap() {
     ["import fs from 'fs';", `const fs = globalThis.${dependencyKey}.fs;`],
     ["import path from 'path';", `const path = globalThis.${dependencyKey}.path;`],
     ["import { getCanonicalOrigin } from '@/lib/site-origin';", `const getCanonicalOrigin = globalThis.${dependencyKey}.getCanonicalOrigin;`],
+    ["import { getServerDataDir } from '@/lib/server-data-dir';", `const getServerDataDir = globalThis.${dependencyKey}.getServerDataDir;`],
     ["import { INDEXABLE_SEO_ROUTES } from '@/lib/seo-routes';", `const INDEXABLE_SEO_ROUTES = globalThis.${dependencyKey}.INDEXABLE_SEO_ROUTES;`],
     [
       "import { DEFAULT_ROUTE_LOCALE, getLocaleRouteConfig, SUPPORTED_ROUTE_LOCALES, type RouteLocale } from '@/lib/locale-routing';",


### PR DESCRIPTION
## 内容：升级组卡引擎到 v0.0.13，修复两个组卡问题

### 1. 控分组卡：低档位（如 25%~33%）组卡始终返回空

- 现象：控分场景下给定目标活动 PT——例如 +133 PT 对应「系数 100% 曲目 + 精确 33% 加成卡组放置一场」——加成组卡永远无结果。
- 原因：引擎为加成组卡（`target=bonus` + `target_bonus_list`）构建候选池时，复用了得分最大化路径的候选裁剪。该裁剪按活动加成与综合力排序淘汰候选，低星卡与未命中活动加成轴的卡全部出局，池内单卡加成下限被抬高到 10%，五张卡下限 50%，低于 50% 的档位由此全部不可达。
- 修复（引擎 47eed28）：加成组卡改用专属候选语义——不再按加成盲裁；单卡加成超过最高目标档的卡在综合力计算前剪除；容量超限时按「角色 + 加成总和」分组去重；0 加成卡保留为填充位。
- 行为变化：零头档位现在可以正常组出；高档位行为不变。

### 2. WL 普通章节组卡：支援位数量与加成不对（终章正常）

- 现象：真实 WL 第三轮章节（活动 id > 180，如 202/205/207/211/214）组卡时，支援卡组只有 20 张并使用 WL2 加成表，且缺少第三轮专属的 336k 综合力上限；终章不受影响。
- 原因：引擎内两套 WL 回合解析不一致，组卡主链路缺少「活动 id > 180 → 第三轮」分支，把这些章节判成第二轮。
- 修复（引擎 f6f4a12）：回合解析统一为覆盖 1/2/3 的同一实现。

## 依赖升级

`@empty-sekai/allium-deck-wasm` 0.0.12 → 0.0.13

## web 侧改动

- `test(deck)`：加成档位用例改为动态取基线卡组的实际加成（盒内必然可组，数据漂移免疫），并对「不可达档 = 空数组」容错；3C 展示解码段同步修正。
- `style`：gofmt `internal/mcp/server.go`（修复 main 现存的 Go 格式检查失败）。
- `fix(seo)`：sitemap characterization 补注入 sitemap.ts 新增的 `getServerDataDir` 依赖（修复 main 现存的 Web 测试失败）。

## 验证

- `npm run test:deck-params`：53 项通过
- `npm run test:deck-payload`：33 项通过
- `node --test tests/characterization/`：全部通过
- gofmt / go build / go test：通过