### PR TITLE
fix(cards): 修正三星卡牌满级为50级并统一定义各稀有度等级上限

### DIFF
--- a/web/src/app/cards/[id]/client.tsx
+++ b/web/src/app/cards/[id]/client.tsx
@@ -18,6 +18,7 @@ import {
     getRarityNumber,
     CardAttribute,
     SUPPORT_UNIT_LABEL_KEYS,
+    CARD_RARITY_MAX_LEVELS,
 } from "@/types/types";
 import { getCardFullUrl, getCardThumbnailUrl, getEventBannerUrl, getGachaLogoUrl, getCardGachaVoiceUrl, getCostumeThumbnailUrl, getCharacterIconUrl } from "@/lib/assets";
 import { useRef } from "react";
@@ -33,13 +34,7 @@ import DetailPageAdCard from "@/components/DetailPageAdCard";
 import { ICostumeInfo, IMoeCostumeData, PART_TYPE_LABEL_KEYS } from "@/types/costume";
 
 // Max levels by rarity
-const MAX_LEVELS: Record<string, { normal: number; trained?: number }> = {
-    rarity_1: { normal: 20 },
-    rarity_2: { normal: 30 },
-    rarity_3: { normal: 50, trained: 60 },
-    rarity_4: { normal: 50, trained: 60 },
-    rarity_birthday: { normal: 50, trained: 60 },
-};
+const MAX_LEVELS = CARD_RARITY_MAX_LEVELS;
 
 interface CardSupplyInfo {
     id: number;
@@ -451,7 +446,7 @@ export default function CardDetailPage({ id }: { initialData?: unknown; id?: num
                                     Array.from({ length: rarityNum }).map((_, i) => (
                                         <Image
                                             key={i}
-                                            src={showTrained && cardLevel > normalMaxLevel ? "/data/icon/star_trained.webp" : "/data/icon/star.webp"}
+                                            src={effectiveShowTrained && cardLevel > normalMaxLevel ? "/data/icon/star_trained.webp" : "/data/icon/star.webp"}
                                             alt="Star"
                                             width={18}
                                             height={18}

--- a/web/src/components/deck-recommend/CustomRulesModal.tsx
+++ b/web/src/components/deck-recommend/CustomRulesModal.tsx
@@ -6,7 +6,7 @@ import { useI18n } from "@/contexts/I18nContext";
 import Modal from "@/components/common/Modal";
 import { getCharacterIconUrl } from "@/lib/assets";
 import { getCharacterName } from "@/lib/i18n";
-import type { ICardInfo } from "@/types/types";
+import { type ICardInfo, CARD_RARITY_MAX_LEVELS } from "@/types/types";
 import SekaiCardThumbnail from "@/components/cards/SekaiCardThumbnail";
 import DataOverridePanel, { type OverrideCatalogItem } from "./DataOverridePanel";
 import type {
@@ -117,14 +117,8 @@ function SingleCardOverrideRow({
 }) {
     const maxLevel = useMemo(() => {
         if (!master) return 60;
-        switch (master.cardRarityType) {
-            case "rarity_1": return 20;
-            case "rarity_2": return 30;
-            case "rarity_3": return 50;
-            case "rarity_4": return 60;
-            case "rarity_birthday": return 60;
-            default: return 60;
-        }
+        const config = CARD_RARITY_MAX_LEVELS[master.cardRarityType];
+        return config ? (config.trained ?? config.normal) : 60;
     }, [master]);
 
     return (

--- a/web/src/types/types.ts
+++ b/web/src/types/types.ts
@@ -301,6 +301,15 @@ export const RARITY_TO_STARS: Record<CardRarityType, number> = {
     rarity_birthday: 4,
 };
 
+// Max levels by rarity (normal untrained, and trained if trainable)
+export const CARD_RARITY_MAX_LEVELS: Record<CardRarityType, { normal: number; trained?: number }> = {
+    rarity_1: { normal: 20 },
+    rarity_2: { normal: 30 },
+    rarity_3: { normal: 40, trained: 50 },
+    rarity_4: { normal: 50, trained: 60 },
+    rarity_birthday: { normal: 60 },
+};
+
 // Rarity display config with colors
 export const RARITY_DISPLAY: Record<number, { label: string; color: string }> = {
     1: { label: "1★", color: "#888888" },


### PR DESCRIPTION
## 概述

修复卡牌详情页 `/cards/[id]` 中三星卡牌满级被误标记为 60 级的问题，并统一定义卡牌稀有度等级上限常量。

## 问题原因

- 之前稀有度满级字典中误将 `rarity_3` 设为 `{ normal: 50, trained: 60 }`（与四星卡牌混淆）；
- 导致三星卡牌详情页初始等级被初始化为 60 级，滑动条上限显示为 `/60`，且由于三星卡基础属性数据只有 50 级，60 级会导致属性数组越界；
- 同时 `rarity_birthday` 生日卡牌此前也误配为 `{ normal: 50, trained: 60 }`（生日卡不能特训，满级为 60 级）。

## 变更内容

1. 在 `web/src/types/types.ts` 中导出标准的 `CARD_RARITY_MAX_LEVELS` 常量：
   - 1★: 20
   - 2★: 30
   - 3★: 40（特训前）/ 50（特训后）
   - 4★: 50（特训前）/ 60（特训后）
   - Birthday: 60（不可特训）
2. 在 `web/src/app/cards/[id]/client.tsx` 引用该配置，三星卡满级正确恢复为 50 级，并优化默认已特训卡面的星标显示逻辑；
3. 在 `web/src/components/deck-recommend/CustomRulesModal.tsx` 复用该配置，统一等级上限计算逻辑。

## 验证
- `npm run lint:i18n` 通过
- `npm run lint:i18n-usage` 通过
- `npm run lint` 通过
- `npm run build:next` 编译打包通过
